### PR TITLE
Render project pages from per-project Markdown content files

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -21,7 +21,9 @@
         "react": "^18.2.0",
         "react-bootstrap": "^2.10.1",
         "react-dom": "^18.2.0",
-        "react-router-dom": "^7.18.0"
+        "react-markdown": "^10.1.0",
+        "react-router-dom": "^7.18.0",
+        "rehype-raw": "^7.0.0"
       },
       "devDependencies": {
         "@types/jquery": "^3.5.29",
@@ -1266,11 +1268,37 @@
         "@babel/types": "^7.20.7"
       }
     },
+    "node_modules/@types/debug": {
+      "version": "4.1.13",
+      "resolved": "https://registry.npmjs.org/@types/debug/-/debug-4.1.13.tgz",
+      "integrity": "sha512-KSVgmQmzMwPlmtljOomayoR89W4FynCAi3E8PPs7vmDVPe84hT+vGPKkJfThkmXs0x0jAaa9U8uW8bbfyS2fWw==",
+      "license": "MIT",
+      "dependencies": {
+        "@types/ms": "*"
+      }
+    },
     "node_modules/@types/estree": {
       "version": "1.0.5",
       "resolved": "https://registry.npmjs.org/@types/estree/-/estree-1.0.5.tgz",
-      "integrity": "sha512-/kYRxGDLWzHOB7q+wtSUQlFrtcdUccpfy+X+9iMBpHK8QLLhx2wIPYuS5DYtR9Wa/YlZAbIovy7qVdB1Aq6Lyw==",
-      "dev": true
+      "integrity": "sha512-/kYRxGDLWzHOB7q+wtSUQlFrtcdUccpfy+X+9iMBpHK8QLLhx2wIPYuS5DYtR9Wa/YlZAbIovy7qVdB1Aq6Lyw=="
+    },
+    "node_modules/@types/estree-jsx": {
+      "version": "1.0.5",
+      "resolved": "https://registry.npmjs.org/@types/estree-jsx/-/estree-jsx-1.0.5.tgz",
+      "integrity": "sha512-52CcUVNFyfb1A2ALocQw/Dd1BQFNmSdkuC3BkZ6iqhdMfQz7JWOFRuJFloOzjk+6WijU56m9oKXFAXc7o3Towg==",
+      "license": "MIT",
+      "dependencies": {
+        "@types/estree": "*"
+      }
+    },
+    "node_modules/@types/hast": {
+      "version": "3.0.5",
+      "resolved": "https://registry.npmjs.org/@types/hast/-/hast-3.0.5.tgz",
+      "integrity": "sha512-rp/ezSWaD1m44dPKICGhiskI13nVr7qTloFwDa/IYkhhf5nzwP+zIQcIJh3WIFSBOy/H1PzB40jPjMDksN4F+g==",
+      "license": "MIT",
+      "dependencies": {
+        "@types/unist": "*"
+      }
     },
     "node_modules/@types/jquery": {
       "version": "3.5.29",
@@ -1281,6 +1309,21 @@
         "@types/sizzle": "*"
       }
     },
+    "node_modules/@types/mdast": {
+      "version": "4.0.4",
+      "resolved": "https://registry.npmjs.org/@types/mdast/-/mdast-4.0.4.tgz",
+      "integrity": "sha512-kGaNbPh1k7AFzgpud/gMdvIm5xuECykRR+JnWKQno9TAXVa6WIVCGTPvYGekIDL4uwCZQSYbUxNBSb1aUo79oA==",
+      "license": "MIT",
+      "dependencies": {
+        "@types/unist": "*"
+      }
+    },
+    "node_modules/@types/ms": {
+      "version": "2.1.0",
+      "resolved": "https://registry.npmjs.org/@types/ms/-/ms-2.1.0.tgz",
+      "integrity": "sha512-GsCCIZDE/p3i96vtEqx+7dBUGXrc7zeSK3wwPHIaRThS+9OhWIXRqzs4d6k1SVU8g91DrNRWxWUGhp5KXQb2VA==",
+      "license": "MIT"
+    },
     "node_modules/@types/prop-types": {
       "version": "15.7.11",
       "resolved": "https://registry.npmjs.org/@types/prop-types/-/prop-types-15.7.11.tgz",
@@ -1290,6 +1333,7 @@
       "version": "18.2.64",
       "resolved": "https://registry.npmjs.org/@types/react/-/react-18.2.64.tgz",
       "integrity": "sha512-MlmPvHgjj2p3vZaxbQgFUQFvD8QiZwACfGqEdDSWou5yISWxDQ4/74nCAwsUiX7UFLKZz3BbVSPj+YxeoGGCfg==",
+      "peer": true,
       "dependencies": {
         "@types/prop-types": "*",
         "@types/scheduler": "*",
@@ -1324,6 +1368,12 @@
       "integrity": "sha512-0vWLNK2D5MT9dg0iOo8GlKguPAU02QjmZitPEsXRuJXU/OGIOt9vT9Fc26wtYuavLxtO45v9PGleoL9Z0k1LHg==",
       "dev": true
     },
+    "node_modules/@types/unist": {
+      "version": "3.0.3",
+      "resolved": "https://registry.npmjs.org/@types/unist/-/unist-3.0.3.tgz",
+      "integrity": "sha512-ko/gIFJRv177XgZsZcBwnqJN5x/Gien8qNOn0D5bQU/zAzVf9Zt3BlcUiLqhV9y4ARk0GbT3tnUiPNgnTXzc/Q==",
+      "license": "MIT"
+    },
     "node_modules/@types/warning": {
       "version": "3.0.3",
       "resolved": "https://registry.npmjs.org/@types/warning/-/warning-3.0.3.tgz",
@@ -1332,8 +1382,7 @@
     "node_modules/@ungap/structured-clone": {
       "version": "1.2.0",
       "resolved": "https://registry.npmjs.org/@ungap/structured-clone/-/structured-clone-1.2.0.tgz",
-      "integrity": "sha512-zuVdFrMJiuCDQUMCzQaD6KL28MjnqqN8XnAqiEq9PNm/hCPTSGfrXCOfwj1ow4LFb/tNymJPwsNbVePc1xFqrQ==",
-      "dev": true
+      "integrity": "sha512-zuVdFrMJiuCDQUMCzQaD6KL28MjnqqN8XnAqiEq9PNm/hCPTSGfrXCOfwj1ow4LFb/tNymJPwsNbVePc1xFqrQ=="
     },
     "node_modules/@vitejs/plugin-react": {
       "version": "4.2.1",
@@ -1624,6 +1673,16 @@
         "url": "https://github.com/sponsors/ljharb"
       }
     },
+    "node_modules/bail": {
+      "version": "2.0.2",
+      "resolved": "https://registry.npmjs.org/bail/-/bail-2.0.2.tgz",
+      "integrity": "sha512-0xO6mYd7JB2YesxDKplafRpsiOzPt9V02ddPCLbY1xYGPOX24NTyN50qnUxgCPcSoYMhKpAuBTjQoRZCAkUDRw==",
+      "license": "MIT",
+      "funding": {
+        "type": "github",
+        "url": "https://github.com/sponsors/wooorm"
+      }
+    },
     "node_modules/balanced-match": {
       "version": "1.0.2",
       "resolved": "https://registry.npmjs.org/balanced-match/-/balanced-match-1.0.2.tgz",
@@ -1782,6 +1841,16 @@
         }
       ]
     },
+    "node_modules/ccount": {
+      "version": "2.0.1",
+      "resolved": "https://registry.npmjs.org/ccount/-/ccount-2.0.1.tgz",
+      "integrity": "sha512-eyrF0jiFpY+3drT6383f1qhkbGsLSifNAjA61IUjZjmLCWjItY6LB9ft9YhoDgwfmclB2zhu51Lc7+95b8NRAg==",
+      "license": "MIT",
+      "funding": {
+        "type": "github",
+        "url": "https://github.com/sponsors/wooorm"
+      }
+    },
     "node_modules/chalk": {
       "version": "2.4.2",
       "resolved": "https://registry.npmjs.org/chalk/-/chalk-2.4.2.tgz",
@@ -1794,6 +1863,46 @@
       },
       "engines": {
         "node": ">=4"
+      }
+    },
+    "node_modules/character-entities": {
+      "version": "2.0.2",
+      "resolved": "https://registry.npmjs.org/character-entities/-/character-entities-2.0.2.tgz",
+      "integrity": "sha512-shx7oQ0Awen/BRIdkjkvz54PnEEI/EjwXDSIZp86/KKdbafHh1Df/RYGBhn4hbe2+uKC9FnT5UCEdyPz3ai9hQ==",
+      "license": "MIT",
+      "funding": {
+        "type": "github",
+        "url": "https://github.com/sponsors/wooorm"
+      }
+    },
+    "node_modules/character-entities-html4": {
+      "version": "2.1.0",
+      "resolved": "https://registry.npmjs.org/character-entities-html4/-/character-entities-html4-2.1.0.tgz",
+      "integrity": "sha512-1v7fgQRj6hnSwFpq1Eu0ynr/CDEw0rXo2B61qXrLNdHZmPKgb7fqS1a2JwF0rISo9q77jDI8VMEHoApn8qDoZA==",
+      "license": "MIT",
+      "funding": {
+        "type": "github",
+        "url": "https://github.com/sponsors/wooorm"
+      }
+    },
+    "node_modules/character-entities-legacy": {
+      "version": "3.0.0",
+      "resolved": "https://registry.npmjs.org/character-entities-legacy/-/character-entities-legacy-3.0.0.tgz",
+      "integrity": "sha512-RpPp0asT/6ufRm//AJVwpViZbGM/MkjQFxJccQRHmISF/22NBtsHqAWmL+/pmkPWoIUJdWyeVleTl1wydHATVQ==",
+      "license": "MIT",
+      "funding": {
+        "type": "github",
+        "url": "https://github.com/sponsors/wooorm"
+      }
+    },
+    "node_modules/character-reference-invalid": {
+      "version": "2.0.1",
+      "resolved": "https://registry.npmjs.org/character-reference-invalid/-/character-reference-invalid-2.0.1.tgz",
+      "integrity": "sha512-iBZ4F4wRbyORVsu0jPV7gXkOsGYjGHPmAyv+HiHG8gi5PtC9KI2j1+v8/tlibRvjoWX027ypmG/n0HtO5t7unw==",
+      "license": "MIT",
+      "funding": {
+        "type": "github",
+        "url": "https://github.com/sponsors/wooorm"
       }
     },
     "node_modules/classnames": {
@@ -1815,6 +1924,16 @@
       "resolved": "https://registry.npmjs.org/color-name/-/color-name-1.1.3.tgz",
       "integrity": "sha512-72fSenhMw2HZMTVHeCA9KCmpEIbzWiQsjN+BHcBbS9vr1mtt+vJjPdksIBNUmKAW8TFUDPJK5SUU3QhE9NEXDw==",
       "dev": true
+    },
+    "node_modules/comma-separated-tokens": {
+      "version": "2.0.3",
+      "resolved": "https://registry.npmjs.org/comma-separated-tokens/-/comma-separated-tokens-2.0.3.tgz",
+      "integrity": "sha512-Fu4hJdvzeylCfQPp9SGWidpzrMs7tTrlu6Vb8XGaRGck8QSNZJJp538Wrb60Lax4fPwR64ViY468OIUTbRlGZg==",
+      "license": "MIT",
+      "funding": {
+        "type": "github",
+        "url": "https://github.com/sponsors/wooorm"
+      }
     },
     "node_modules/commander": {
       "version": "11.1.0",
@@ -1910,7 +2029,6 @@
       "version": "4.3.4",
       "resolved": "https://registry.npmjs.org/debug/-/debug-4.3.4.tgz",
       "integrity": "sha512-PRWFHuSU3eDtQJPvnNY7Jcket1j0t5OuOsFzPPzsekD52Zl8qUfFIPEiswXqIvHWGVHOgX+7G/vCNNhehwxfkQ==",
-      "dev": true,
       "dependencies": {
         "ms": "2.1.2"
       },
@@ -1921,6 +2039,19 @@
         "supports-color": {
           "optional": true
         }
+      }
+    },
+    "node_modules/decode-named-character-reference": {
+      "version": "1.3.0",
+      "resolved": "https://registry.npmjs.org/decode-named-character-reference/-/decode-named-character-reference-1.3.0.tgz",
+      "integrity": "sha512-GtpQYB283KrPp6nRw50q3U9/VfOutZOe103qlN7BPP6Ad27xYnOIWv4lPzo8HCAL+mMZofJ9KEy30fq6MfaK6Q==",
+      "license": "MIT",
+      "dependencies": {
+        "character-entities": "^2.0.0"
+      },
+      "funding": {
+        "type": "github",
+        "url": "https://github.com/sponsors/wooorm"
       }
     },
     "node_modules/deep-is": {
@@ -1987,6 +2118,19 @@
         "npm": "1.2.8000 || >= 1.4.16"
       }
     },
+    "node_modules/devlop": {
+      "version": "1.1.0",
+      "resolved": "https://registry.npmjs.org/devlop/-/devlop-1.1.0.tgz",
+      "integrity": "sha512-RWmIqhcFf1lRYBvNmr7qTNuyCt/7/ns2jbpp1+PalgE/rDQcBT0fioSMUpJ93irlUhC5hrg4cYqe6U+0ImW0rA==",
+      "license": "MIT",
+      "dependencies": {
+        "dequal": "^2.0.0"
+      },
+      "funding": {
+        "type": "github",
+        "url": "https://github.com/sponsors/wooorm"
+      }
+    },
     "node_modules/doctrine": {
       "version": "3.0.0",
       "resolved": "https://registry.npmjs.org/doctrine/-/doctrine-3.0.0.tgz",
@@ -2047,6 +2191,18 @@
       "integrity": "sha512-TPJXq8JqFaVYm2CWmPvnP2Iyo4ZSM7/QKcSmuMLDObfpH5fi7RUGmd/rTDf+rut/saiDiQEeVTNgAmJEdAOx0w==",
       "engines": {
         "node": ">= 0.8"
+      }
+    },
+    "node_modules/entities": {
+      "version": "6.0.1",
+      "resolved": "https://registry.npmjs.org/entities/-/entities-6.0.1.tgz",
+      "integrity": "sha512-aN97NXWF6AWBTahfVOIrB/NShkzi5H7F9r1s9mD3cDj4Ko5f2qhhVoYMibXF7GlLveb/D2ioWay8lxI97Ven3g==",
+      "license": "BSD-2-Clause",
+      "engines": {
+        "node": ">=0.12"
+      },
+      "funding": {
+        "url": "https://github.com/fb55/entities?sponsor=1"
       }
     },
     "node_modules/es-abstract": {
@@ -2546,6 +2702,16 @@
         "node": ">=4.0"
       }
     },
+    "node_modules/estree-util-is-identifier-name": {
+      "version": "3.0.0",
+      "resolved": "https://registry.npmjs.org/estree-util-is-identifier-name/-/estree-util-is-identifier-name-3.0.0.tgz",
+      "integrity": "sha512-hFtqIDZTIUZ9BXLb8y4pYGyk6+wekIivNVTcmvk8NoOh+VeRn5y6cEHzbURrWbfp1fIqdVipilzj+lfaadNZmg==",
+      "license": "MIT",
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/unified"
+      }
+    },
     "node_modules/esutils": {
       "version": "2.0.3",
       "resolved": "https://registry.npmjs.org/esutils/-/esutils-2.0.3.tgz",
@@ -2616,6 +2782,12 @@
       "version": "2.0.0",
       "resolved": "https://registry.npmjs.org/ms/-/ms-2.0.0.tgz",
       "integrity": "sha512-Tpp60P6IUJDTuOq/5Z8cdskzJujfwqfOTkrwIwj7IRISpnkJnT6SyJ4PCPnGMoFjC9ddhal5KVIYtAt97ix05A=="
+    },
+    "node_modules/extend": {
+      "version": "3.0.2",
+      "resolved": "https://registry.npmjs.org/extend/-/extend-3.0.2.tgz",
+      "integrity": "sha512-fjquC59cD7CyW6urNXK0FBufkZcoiGG80wTuPujX590cB5Ttln20E2UB4S/WARVqhXffZl2LNgS+gQdPIIim/g==",
+      "license": "MIT"
     },
     "node_modules/fast-deep-equal": {
       "version": "3.1.3",
@@ -3120,6 +3292,160 @@
         "node": ">= 0.4"
       }
     },
+    "node_modules/hast-util-from-parse5": {
+      "version": "8.0.3",
+      "resolved": "https://registry.npmjs.org/hast-util-from-parse5/-/hast-util-from-parse5-8.0.3.tgz",
+      "integrity": "sha512-3kxEVkEKt0zvcZ3hCRYI8rqrgwtlIOFMWkbclACvjlDw8Li9S2hk/d51OI0nr/gIpdMHNepwgOKqZ/sy0Clpyg==",
+      "license": "MIT",
+      "dependencies": {
+        "@types/hast": "^3.0.0",
+        "@types/unist": "^3.0.0",
+        "devlop": "^1.0.0",
+        "hastscript": "^9.0.0",
+        "property-information": "^7.0.0",
+        "vfile": "^6.0.0",
+        "vfile-location": "^5.0.0",
+        "web-namespaces": "^2.0.0"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/unified"
+      }
+    },
+    "node_modules/hast-util-parse-selector": {
+      "version": "4.0.0",
+      "resolved": "https://registry.npmjs.org/hast-util-parse-selector/-/hast-util-parse-selector-4.0.0.tgz",
+      "integrity": "sha512-wkQCkSYoOGCRKERFWcxMVMOcYE2K1AaNLU8DXS9arxnLOUEWbOXKXiJUNzEpqZ3JOKpnha3jkFrumEjVliDe7A==",
+      "license": "MIT",
+      "dependencies": {
+        "@types/hast": "^3.0.0"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/unified"
+      }
+    },
+    "node_modules/hast-util-raw": {
+      "version": "9.1.0",
+      "resolved": "https://registry.npmjs.org/hast-util-raw/-/hast-util-raw-9.1.0.tgz",
+      "integrity": "sha512-Y8/SBAHkZGoNkpzqqfCldijcuUKh7/su31kEBp67cFY09Wy0mTRgtsLYsiIxMJxlu0f6AA5SUTbDR8K0rxnbUw==",
+      "license": "MIT",
+      "dependencies": {
+        "@types/hast": "^3.0.0",
+        "@types/unist": "^3.0.0",
+        "@ungap/structured-clone": "^1.0.0",
+        "hast-util-from-parse5": "^8.0.0",
+        "hast-util-to-parse5": "^8.0.0",
+        "html-void-elements": "^3.0.0",
+        "mdast-util-to-hast": "^13.0.0",
+        "parse5": "^7.0.0",
+        "unist-util-position": "^5.0.0",
+        "unist-util-visit": "^5.0.0",
+        "vfile": "^6.0.0",
+        "web-namespaces": "^2.0.0",
+        "zwitch": "^2.0.0"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/unified"
+      }
+    },
+    "node_modules/hast-util-to-jsx-runtime": {
+      "version": "2.3.6",
+      "resolved": "https://registry.npmjs.org/hast-util-to-jsx-runtime/-/hast-util-to-jsx-runtime-2.3.6.tgz",
+      "integrity": "sha512-zl6s8LwNyo1P9uw+XJGvZtdFF1GdAkOg8ujOw+4Pyb76874fLps4ueHXDhXWdk6YHQ6OgUtinliG7RsYvCbbBg==",
+      "license": "MIT",
+      "dependencies": {
+        "@types/estree": "^1.0.0",
+        "@types/hast": "^3.0.0",
+        "@types/unist": "^3.0.0",
+        "comma-separated-tokens": "^2.0.0",
+        "devlop": "^1.0.0",
+        "estree-util-is-identifier-name": "^3.0.0",
+        "hast-util-whitespace": "^3.0.0",
+        "mdast-util-mdx-expression": "^2.0.0",
+        "mdast-util-mdx-jsx": "^3.0.0",
+        "mdast-util-mdxjs-esm": "^2.0.0",
+        "property-information": "^7.0.0",
+        "space-separated-tokens": "^2.0.0",
+        "style-to-js": "^1.0.0",
+        "unist-util-position": "^5.0.0",
+        "vfile-message": "^4.0.0"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/unified"
+      }
+    },
+    "node_modules/hast-util-to-parse5": {
+      "version": "8.0.1",
+      "resolved": "https://registry.npmjs.org/hast-util-to-parse5/-/hast-util-to-parse5-8.0.1.tgz",
+      "integrity": "sha512-MlWT6Pjt4CG9lFCjiz4BH7l9wmrMkfkJYCxFwKQic8+RTZgWPuWxwAfjJElsXkex7DJjfSJsQIt931ilUgmwdA==",
+      "license": "MIT",
+      "dependencies": {
+        "@types/hast": "^3.0.0",
+        "comma-separated-tokens": "^2.0.0",
+        "devlop": "^1.0.0",
+        "property-information": "^7.0.0",
+        "space-separated-tokens": "^2.0.0",
+        "web-namespaces": "^2.0.0",
+        "zwitch": "^2.0.0"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/unified"
+      }
+    },
+    "node_modules/hast-util-whitespace": {
+      "version": "3.0.0",
+      "resolved": "https://registry.npmjs.org/hast-util-whitespace/-/hast-util-whitespace-3.0.0.tgz",
+      "integrity": "sha512-88JUN06ipLwsnv+dVn+OIYOvAuvBMy/Qoi6O7mQHxdPXpjy+Cd6xRkWwux7DKO+4sYILtLBRIKgsdpS2gQc7qw==",
+      "license": "MIT",
+      "dependencies": {
+        "@types/hast": "^3.0.0"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/unified"
+      }
+    },
+    "node_modules/hastscript": {
+      "version": "9.0.1",
+      "resolved": "https://registry.npmjs.org/hastscript/-/hastscript-9.0.1.tgz",
+      "integrity": "sha512-g7df9rMFX/SPi34tyGCyUBREQoKkapwdY/T04Qn9TDWfHhAYt4/I0gMVirzK5wEzeUqIjEB+LXC/ypb7Aqno5w==",
+      "license": "MIT",
+      "dependencies": {
+        "@types/hast": "^3.0.0",
+        "comma-separated-tokens": "^2.0.0",
+        "hast-util-parse-selector": "^4.0.0",
+        "property-information": "^7.0.0",
+        "space-separated-tokens": "^2.0.0"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/unified"
+      }
+    },
+    "node_modules/html-url-attributes": {
+      "version": "3.0.1",
+      "resolved": "https://registry.npmjs.org/html-url-attributes/-/html-url-attributes-3.0.1.tgz",
+      "integrity": "sha512-ol6UPyBWqsrO6EJySPz2O7ZSr856WDrEzM5zMqp+FJJLGMW35cLYmmZnl0vztAZxRUoNZJFTCohfjuIJ8I4QBQ==",
+      "license": "MIT",
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/unified"
+      }
+    },
+    "node_modules/html-void-elements": {
+      "version": "3.0.0",
+      "resolved": "https://registry.npmjs.org/html-void-elements/-/html-void-elements-3.0.0.tgz",
+      "integrity": "sha512-bEqo66MRXsUGxWHV5IP0PUiAWwoEjba4VCzg0LjFJBpchPaTfyfCKTG6bc5F8ucKec3q5y6qOdGyYTSBEvhCrg==",
+      "license": "MIT",
+      "funding": {
+        "type": "github",
+        "url": "https://github.com/sponsors/wooorm"
+      }
+    },
     "node_modules/http-errors": {
       "version": "2.0.0",
       "resolved": "https://registry.npmjs.org/http-errors/-/http-errors-2.0.0.tgz",
@@ -3195,6 +3521,12 @@
       "resolved": "https://registry.npmjs.org/inherits/-/inherits-2.0.4.tgz",
       "integrity": "sha512-k/vGaX4/Yla3WzyMCvTQOXYeIHvqOKtnqBduzTHpzpQZzAskKMhZ2K+EnBiSM9zGSoIFeMpXKxa4dYeZIQqewQ=="
     },
+    "node_modules/inline-style-parser": {
+      "version": "0.2.7",
+      "resolved": "https://registry.npmjs.org/inline-style-parser/-/inline-style-parser-0.2.7.tgz",
+      "integrity": "sha512-Nb2ctOyNR8DqQoR0OwRG95uNWIC0C1lCgf5Naz5H6Ji72KZ8OcFZLz2P5sNgwlyoJ8Yif11oMuYs5pBQa86csA==",
+      "license": "MIT"
+    },
     "node_modules/internal-slot": {
       "version": "1.0.7",
       "resolved": "https://registry.npmjs.org/internal-slot/-/internal-slot-1.0.7.tgz",
@@ -3223,6 +3555,30 @@
       "integrity": "sha512-0KI/607xoxSToH7GjN1FfSbLoU0+btTicjsQSWQlh/hZykN8KpmMf7uYwPW3R+akZ6R/w18ZlXSHBYXiYUPO3g==",
       "engines": {
         "node": ">= 0.10"
+      }
+    },
+    "node_modules/is-alphabetical": {
+      "version": "2.0.1",
+      "resolved": "https://registry.npmjs.org/is-alphabetical/-/is-alphabetical-2.0.1.tgz",
+      "integrity": "sha512-FWyyY60MeTNyeSRpkM2Iry0G9hpr7/9kD40mD/cGQEuilcZYS4okz8SN2Q6rLCJ8gbCt6fN+rC+6tMGS99LaxQ==",
+      "license": "MIT",
+      "funding": {
+        "type": "github",
+        "url": "https://github.com/sponsors/wooorm"
+      }
+    },
+    "node_modules/is-alphanumerical": {
+      "version": "2.0.1",
+      "resolved": "https://registry.npmjs.org/is-alphanumerical/-/is-alphanumerical-2.0.1.tgz",
+      "integrity": "sha512-hmbYhX/9MUMF5uh7tOXyK/n0ZvWpad5caBA17GsC6vyuCqaWliRG5K1qS9inmUhEMaOBIW7/whAnSwveW/LtZw==",
+      "license": "MIT",
+      "dependencies": {
+        "is-alphabetical": "^2.0.0",
+        "is-decimal": "^2.0.0"
+      },
+      "funding": {
+        "type": "github",
+        "url": "https://github.com/sponsors/wooorm"
       }
     },
     "node_modules/is-array-buffer": {
@@ -3323,6 +3679,16 @@
         "url": "https://github.com/sponsors/ljharb"
       }
     },
+    "node_modules/is-decimal": {
+      "version": "2.0.1",
+      "resolved": "https://registry.npmjs.org/is-decimal/-/is-decimal-2.0.1.tgz",
+      "integrity": "sha512-AAB9hiomQs5DXWcRB1rqsxGUstbRroFOPPVAomNk/3XHR5JyEZChOyTWe2oayKnsSsr/kcGqF+z6yuH6HHpN0A==",
+      "license": "MIT",
+      "funding": {
+        "type": "github",
+        "url": "https://github.com/sponsors/wooorm"
+      }
+    },
     "node_modules/is-extglob": {
       "version": "2.1.1",
       "resolved": "https://registry.npmjs.org/is-extglob/-/is-extglob-2.1.1.tgz",
@@ -3371,6 +3737,16 @@
         "node": ">=0.10.0"
       }
     },
+    "node_modules/is-hexadecimal": {
+      "version": "2.0.1",
+      "resolved": "https://registry.npmjs.org/is-hexadecimal/-/is-hexadecimal-2.0.1.tgz",
+      "integrity": "sha512-DgZQp241c8oO6cA1SbTEWiXeoxV42vlcJxgH+B3hi1AiqqKruZR3ZGF8In3fj4+/y/7rHvlOZLZtgJ/4ttYGZg==",
+      "license": "MIT",
+      "funding": {
+        "type": "github",
+        "url": "https://github.com/sponsors/wooorm"
+      }
+    },
     "node_modules/is-map": {
       "version": "2.0.3",
       "resolved": "https://registry.npmjs.org/is-map/-/is-map-2.0.3.tgz",
@@ -3417,6 +3793,18 @@
       "dev": true,
       "engines": {
         "node": ">=8"
+      }
+    },
+    "node_modules/is-plain-obj": {
+      "version": "4.1.0",
+      "resolved": "https://registry.npmjs.org/is-plain-obj/-/is-plain-obj-4.1.0.tgz",
+      "integrity": "sha512-+Pgi+vMuUNkJyExiMBt5IlFoMyKnr5zhJ4Uspz58WOhBF5QoIZkFyNHIbBAtHwzVAgk5RtndVNsDRN61/mmDqg==",
+      "license": "MIT",
+      "engines": {
+        "node": ">=12"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/sindresorhus"
       }
     },
     "node_modules/is-regex": {
@@ -3697,6 +4085,16 @@
       "integrity": "sha512-0KpjqXRVvrYyCsX1swR/XTK0va6VQkQM6MNo7PqW77ByjAhoARA8EfrP1N4+KlKj8YS0ZUCtRT/YUuhyYDujIQ==",
       "dev": true
     },
+    "node_modules/longest-streak": {
+      "version": "3.1.0",
+      "resolved": "https://registry.npmjs.org/longest-streak/-/longest-streak-3.1.0.tgz",
+      "integrity": "sha512-9Ri+o0JYgehTaVBBDoMqIl8GXtbWg711O3srftcHhZ0dqnETqLaoIK0x17fUw9rFSlK/0NlsKe0Ahhyl5pXE2g==",
+      "license": "MIT",
+      "funding": {
+        "type": "github",
+        "url": "https://github.com/sponsors/wooorm"
+      }
+    },
     "node_modules/loose-envify": {
       "version": "1.4.0",
       "resolved": "https://registry.npmjs.org/loose-envify/-/loose-envify-1.4.0.tgz",
@@ -3732,6 +4130,159 @@
         "url": "https://github.com/sponsors/sindresorhus"
       }
     },
+    "node_modules/mdast-util-from-markdown": {
+      "version": "2.0.3",
+      "resolved": "https://registry.npmjs.org/mdast-util-from-markdown/-/mdast-util-from-markdown-2.0.3.tgz",
+      "integrity": "sha512-W4mAWTvSlKvf8L6J+VN9yLSqQ9AOAAvHuoDAmPkz4dHf553m5gVj2ejadHJhoJmcmxEnOv6Pa8XJhpxE93kb8Q==",
+      "license": "MIT",
+      "dependencies": {
+        "@types/mdast": "^4.0.0",
+        "@types/unist": "^3.0.0",
+        "decode-named-character-reference": "^1.0.0",
+        "devlop": "^1.0.0",
+        "mdast-util-to-string": "^4.0.0",
+        "micromark": "^4.0.0",
+        "micromark-util-decode-numeric-character-reference": "^2.0.0",
+        "micromark-util-decode-string": "^2.0.0",
+        "micromark-util-normalize-identifier": "^2.0.0",
+        "micromark-util-symbol": "^2.0.0",
+        "micromark-util-types": "^2.0.0",
+        "unist-util-stringify-position": "^4.0.0"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/unified"
+      }
+    },
+    "node_modules/mdast-util-mdx-expression": {
+      "version": "2.0.1",
+      "resolved": "https://registry.npmjs.org/mdast-util-mdx-expression/-/mdast-util-mdx-expression-2.0.1.tgz",
+      "integrity": "sha512-J6f+9hUp+ldTZqKRSg7Vw5V6MqjATc+3E4gf3CFNcuZNWD8XdyI6zQ8GqH7f8169MM6P7hMBRDVGnn7oHB9kXQ==",
+      "license": "MIT",
+      "dependencies": {
+        "@types/estree-jsx": "^1.0.0",
+        "@types/hast": "^3.0.0",
+        "@types/mdast": "^4.0.0",
+        "devlop": "^1.0.0",
+        "mdast-util-from-markdown": "^2.0.0",
+        "mdast-util-to-markdown": "^2.0.0"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/unified"
+      }
+    },
+    "node_modules/mdast-util-mdx-jsx": {
+      "version": "3.2.0",
+      "resolved": "https://registry.npmjs.org/mdast-util-mdx-jsx/-/mdast-util-mdx-jsx-3.2.0.tgz",
+      "integrity": "sha512-lj/z8v0r6ZtsN/cGNNtemmmfoLAFZnjMbNyLzBafjzikOM+glrjNHPlf6lQDOTccj9n5b0PPihEBbhneMyGs1Q==",
+      "license": "MIT",
+      "dependencies": {
+        "@types/estree-jsx": "^1.0.0",
+        "@types/hast": "^3.0.0",
+        "@types/mdast": "^4.0.0",
+        "@types/unist": "^3.0.0",
+        "ccount": "^2.0.0",
+        "devlop": "^1.1.0",
+        "mdast-util-from-markdown": "^2.0.0",
+        "mdast-util-to-markdown": "^2.0.0",
+        "parse-entities": "^4.0.0",
+        "stringify-entities": "^4.0.0",
+        "unist-util-stringify-position": "^4.0.0",
+        "vfile-message": "^4.0.0"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/unified"
+      }
+    },
+    "node_modules/mdast-util-mdxjs-esm": {
+      "version": "2.0.1",
+      "resolved": "https://registry.npmjs.org/mdast-util-mdxjs-esm/-/mdast-util-mdxjs-esm-2.0.1.tgz",
+      "integrity": "sha512-EcmOpxsZ96CvlP03NghtH1EsLtr0n9Tm4lPUJUBccV9RwUOneqSycg19n5HGzCf+10LozMRSObtVr3ee1WoHtg==",
+      "license": "MIT",
+      "dependencies": {
+        "@types/estree-jsx": "^1.0.0",
+        "@types/hast": "^3.0.0",
+        "@types/mdast": "^4.0.0",
+        "devlop": "^1.0.0",
+        "mdast-util-from-markdown": "^2.0.0",
+        "mdast-util-to-markdown": "^2.0.0"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/unified"
+      }
+    },
+    "node_modules/mdast-util-phrasing": {
+      "version": "4.1.0",
+      "resolved": "https://registry.npmjs.org/mdast-util-phrasing/-/mdast-util-phrasing-4.1.0.tgz",
+      "integrity": "sha512-TqICwyvJJpBwvGAMZjj4J2n0X8QWp21b9l0o7eXyVJ25YNWYbJDVIyD1bZXE6WtV6RmKJVYmQAKWa0zWOABz2w==",
+      "license": "MIT",
+      "dependencies": {
+        "@types/mdast": "^4.0.0",
+        "unist-util-is": "^6.0.0"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/unified"
+      }
+    },
+    "node_modules/mdast-util-to-hast": {
+      "version": "13.2.1",
+      "resolved": "https://registry.npmjs.org/mdast-util-to-hast/-/mdast-util-to-hast-13.2.1.tgz",
+      "integrity": "sha512-cctsq2wp5vTsLIcaymblUriiTcZd0CwWtCbLvrOzYCDZoWyMNV8sZ7krj09FSnsiJi3WVsHLM4k6Dq/yaPyCXA==",
+      "license": "MIT",
+      "dependencies": {
+        "@types/hast": "^3.0.0",
+        "@types/mdast": "^4.0.0",
+        "@ungap/structured-clone": "^1.0.0",
+        "devlop": "^1.0.0",
+        "micromark-util-sanitize-uri": "^2.0.0",
+        "trim-lines": "^3.0.0",
+        "unist-util-position": "^5.0.0",
+        "unist-util-visit": "^5.0.0",
+        "vfile": "^6.0.0"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/unified"
+      }
+    },
+    "node_modules/mdast-util-to-markdown": {
+      "version": "2.1.2",
+      "resolved": "https://registry.npmjs.org/mdast-util-to-markdown/-/mdast-util-to-markdown-2.1.2.tgz",
+      "integrity": "sha512-xj68wMTvGXVOKonmog6LwyJKrYXZPvlwabaryTjLh9LuvovB/KAH+kvi8Gjj+7rJjsFi23nkUxRQv1KqSroMqA==",
+      "license": "MIT",
+      "dependencies": {
+        "@types/mdast": "^4.0.0",
+        "@types/unist": "^3.0.0",
+        "longest-streak": "^3.0.0",
+        "mdast-util-phrasing": "^4.0.0",
+        "mdast-util-to-string": "^4.0.0",
+        "micromark-util-classify-character": "^2.0.0",
+        "micromark-util-decode-string": "^2.0.0",
+        "unist-util-visit": "^5.0.0",
+        "zwitch": "^2.0.0"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/unified"
+      }
+    },
+    "node_modules/mdast-util-to-string": {
+      "version": "4.0.0",
+      "resolved": "https://registry.npmjs.org/mdast-util-to-string/-/mdast-util-to-string-4.0.0.tgz",
+      "integrity": "sha512-0H44vDimn51F0YwvxSJSm0eCDOJTRlmN0R1yBh4HLj9wiV1Dn0QoXGbvFAWj2hSItVTlCmBF1hqKlIyUBVFLPg==",
+      "license": "MIT",
+      "dependencies": {
+        "@types/mdast": "^4.0.0"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/unified"
+      }
+    },
     "node_modules/media-typer": {
       "version": "0.3.0",
       "resolved": "https://registry.npmjs.org/media-typer/-/media-typer-0.3.0.tgz",
@@ -3752,6 +4303,448 @@
       "engines": {
         "node": ">= 0.6"
       }
+    },
+    "node_modules/micromark": {
+      "version": "4.0.2",
+      "resolved": "https://registry.npmjs.org/micromark/-/micromark-4.0.2.tgz",
+      "integrity": "sha512-zpe98Q6kvavpCr1NPVSCMebCKfD7CA2NqZ+rykeNhONIJBpc1tFKt9hucLGwha3jNTNI8lHpctWJWoimVF4PfA==",
+      "funding": [
+        {
+          "type": "GitHub Sponsors",
+          "url": "https://github.com/sponsors/unifiedjs"
+        },
+        {
+          "type": "OpenCollective",
+          "url": "https://opencollective.com/unified"
+        }
+      ],
+      "license": "MIT",
+      "dependencies": {
+        "@types/debug": "^4.0.0",
+        "debug": "^4.0.0",
+        "decode-named-character-reference": "^1.0.0",
+        "devlop": "^1.0.0",
+        "micromark-core-commonmark": "^2.0.0",
+        "micromark-factory-space": "^2.0.0",
+        "micromark-util-character": "^2.0.0",
+        "micromark-util-chunked": "^2.0.0",
+        "micromark-util-combine-extensions": "^2.0.0",
+        "micromark-util-decode-numeric-character-reference": "^2.0.0",
+        "micromark-util-encode": "^2.0.0",
+        "micromark-util-normalize-identifier": "^2.0.0",
+        "micromark-util-resolve-all": "^2.0.0",
+        "micromark-util-sanitize-uri": "^2.0.0",
+        "micromark-util-subtokenize": "^2.0.0",
+        "micromark-util-symbol": "^2.0.0",
+        "micromark-util-types": "^2.0.0"
+      }
+    },
+    "node_modules/micromark-core-commonmark": {
+      "version": "2.0.3",
+      "resolved": "https://registry.npmjs.org/micromark-core-commonmark/-/micromark-core-commonmark-2.0.3.tgz",
+      "integrity": "sha512-RDBrHEMSxVFLg6xvnXmb1Ayr2WzLAWjeSATAoxwKYJV94TeNavgoIdA0a9ytzDSVzBy2YKFK+emCPOEibLeCrg==",
+      "funding": [
+        {
+          "type": "GitHub Sponsors",
+          "url": "https://github.com/sponsors/unifiedjs"
+        },
+        {
+          "type": "OpenCollective",
+          "url": "https://opencollective.com/unified"
+        }
+      ],
+      "license": "MIT",
+      "dependencies": {
+        "decode-named-character-reference": "^1.0.0",
+        "devlop": "^1.0.0",
+        "micromark-factory-destination": "^2.0.0",
+        "micromark-factory-label": "^2.0.0",
+        "micromark-factory-space": "^2.0.0",
+        "micromark-factory-title": "^2.0.0",
+        "micromark-factory-whitespace": "^2.0.0",
+        "micromark-util-character": "^2.0.0",
+        "micromark-util-chunked": "^2.0.0",
+        "micromark-util-classify-character": "^2.0.0",
+        "micromark-util-html-tag-name": "^2.0.0",
+        "micromark-util-normalize-identifier": "^2.0.0",
+        "micromark-util-resolve-all": "^2.0.0",
+        "micromark-util-subtokenize": "^2.0.0",
+        "micromark-util-symbol": "^2.0.0",
+        "micromark-util-types": "^2.0.0"
+      }
+    },
+    "node_modules/micromark-factory-destination": {
+      "version": "2.0.1",
+      "resolved": "https://registry.npmjs.org/micromark-factory-destination/-/micromark-factory-destination-2.0.1.tgz",
+      "integrity": "sha512-Xe6rDdJlkmbFRExpTOmRj9N3MaWmbAgdpSrBQvCFqhezUn4AHqJHbaEnfbVYYiexVSs//tqOdY/DxhjdCiJnIA==",
+      "funding": [
+        {
+          "type": "GitHub Sponsors",
+          "url": "https://github.com/sponsors/unifiedjs"
+        },
+        {
+          "type": "OpenCollective",
+          "url": "https://opencollective.com/unified"
+        }
+      ],
+      "license": "MIT",
+      "dependencies": {
+        "micromark-util-character": "^2.0.0",
+        "micromark-util-symbol": "^2.0.0",
+        "micromark-util-types": "^2.0.0"
+      }
+    },
+    "node_modules/micromark-factory-label": {
+      "version": "2.0.1",
+      "resolved": "https://registry.npmjs.org/micromark-factory-label/-/micromark-factory-label-2.0.1.tgz",
+      "integrity": "sha512-VFMekyQExqIW7xIChcXn4ok29YE3rnuyveW3wZQWWqF4Nv9Wk5rgJ99KzPvHjkmPXF93FXIbBp6YdW3t71/7Vg==",
+      "funding": [
+        {
+          "type": "GitHub Sponsors",
+          "url": "https://github.com/sponsors/unifiedjs"
+        },
+        {
+          "type": "OpenCollective",
+          "url": "https://opencollective.com/unified"
+        }
+      ],
+      "license": "MIT",
+      "dependencies": {
+        "devlop": "^1.0.0",
+        "micromark-util-character": "^2.0.0",
+        "micromark-util-symbol": "^2.0.0",
+        "micromark-util-types": "^2.0.0"
+      }
+    },
+    "node_modules/micromark-factory-space": {
+      "version": "2.0.1",
+      "resolved": "https://registry.npmjs.org/micromark-factory-space/-/micromark-factory-space-2.0.1.tgz",
+      "integrity": "sha512-zRkxjtBxxLd2Sc0d+fbnEunsTj46SWXgXciZmHq0kDYGnck/ZSGj9/wULTV95uoeYiK5hRXP2mJ98Uo4cq/LQg==",
+      "funding": [
+        {
+          "type": "GitHub Sponsors",
+          "url": "https://github.com/sponsors/unifiedjs"
+        },
+        {
+          "type": "OpenCollective",
+          "url": "https://opencollective.com/unified"
+        }
+      ],
+      "license": "MIT",
+      "dependencies": {
+        "micromark-util-character": "^2.0.0",
+        "micromark-util-types": "^2.0.0"
+      }
+    },
+    "node_modules/micromark-factory-title": {
+      "version": "2.0.1",
+      "resolved": "https://registry.npmjs.org/micromark-factory-title/-/micromark-factory-title-2.0.1.tgz",
+      "integrity": "sha512-5bZ+3CjhAd9eChYTHsjy6TGxpOFSKgKKJPJxr293jTbfry2KDoWkhBb6TcPVB4NmzaPhMs1Frm9AZH7OD4Cjzw==",
+      "funding": [
+        {
+          "type": "GitHub Sponsors",
+          "url": "https://github.com/sponsors/unifiedjs"
+        },
+        {
+          "type": "OpenCollective",
+          "url": "https://opencollective.com/unified"
+        }
+      ],
+      "license": "MIT",
+      "dependencies": {
+        "micromark-factory-space": "^2.0.0",
+        "micromark-util-character": "^2.0.0",
+        "micromark-util-symbol": "^2.0.0",
+        "micromark-util-types": "^2.0.0"
+      }
+    },
+    "node_modules/micromark-factory-whitespace": {
+      "version": "2.0.1",
+      "resolved": "https://registry.npmjs.org/micromark-factory-whitespace/-/micromark-factory-whitespace-2.0.1.tgz",
+      "integrity": "sha512-Ob0nuZ3PKt/n0hORHyvoD9uZhr+Za8sFoP+OnMcnWK5lngSzALgQYKMr9RJVOWLqQYuyn6ulqGWSXdwf6F80lQ==",
+      "funding": [
+        {
+          "type": "GitHub Sponsors",
+          "url": "https://github.com/sponsors/unifiedjs"
+        },
+        {
+          "type": "OpenCollective",
+          "url": "https://opencollective.com/unified"
+        }
+      ],
+      "license": "MIT",
+      "dependencies": {
+        "micromark-factory-space": "^2.0.0",
+        "micromark-util-character": "^2.0.0",
+        "micromark-util-symbol": "^2.0.0",
+        "micromark-util-types": "^2.0.0"
+      }
+    },
+    "node_modules/micromark-util-character": {
+      "version": "2.1.1",
+      "resolved": "https://registry.npmjs.org/micromark-util-character/-/micromark-util-character-2.1.1.tgz",
+      "integrity": "sha512-wv8tdUTJ3thSFFFJKtpYKOYiGP2+v96Hvk4Tu8KpCAsTMs6yi+nVmGh1syvSCsaxz45J6Jbw+9DD6g97+NV67Q==",
+      "funding": [
+        {
+          "type": "GitHub Sponsors",
+          "url": "https://github.com/sponsors/unifiedjs"
+        },
+        {
+          "type": "OpenCollective",
+          "url": "https://opencollective.com/unified"
+        }
+      ],
+      "license": "MIT",
+      "dependencies": {
+        "micromark-util-symbol": "^2.0.0",
+        "micromark-util-types": "^2.0.0"
+      }
+    },
+    "node_modules/micromark-util-chunked": {
+      "version": "2.0.1",
+      "resolved": "https://registry.npmjs.org/micromark-util-chunked/-/micromark-util-chunked-2.0.1.tgz",
+      "integrity": "sha512-QUNFEOPELfmvv+4xiNg2sRYeS/P84pTW0TCgP5zc9FpXetHY0ab7SxKyAQCNCc1eK0459uoLI1y5oO5Vc1dbhA==",
+      "funding": [
+        {
+          "type": "GitHub Sponsors",
+          "url": "https://github.com/sponsors/unifiedjs"
+        },
+        {
+          "type": "OpenCollective",
+          "url": "https://opencollective.com/unified"
+        }
+      ],
+      "license": "MIT",
+      "dependencies": {
+        "micromark-util-symbol": "^2.0.0"
+      }
+    },
+    "node_modules/micromark-util-classify-character": {
+      "version": "2.0.1",
+      "resolved": "https://registry.npmjs.org/micromark-util-classify-character/-/micromark-util-classify-character-2.0.1.tgz",
+      "integrity": "sha512-K0kHzM6afW/MbeWYWLjoHQv1sgg2Q9EccHEDzSkxiP/EaagNzCm7T/WMKZ3rjMbvIpvBiZgwR3dKMygtA4mG1Q==",
+      "funding": [
+        {
+          "type": "GitHub Sponsors",
+          "url": "https://github.com/sponsors/unifiedjs"
+        },
+        {
+          "type": "OpenCollective",
+          "url": "https://opencollective.com/unified"
+        }
+      ],
+      "license": "MIT",
+      "dependencies": {
+        "micromark-util-character": "^2.0.0",
+        "micromark-util-symbol": "^2.0.0",
+        "micromark-util-types": "^2.0.0"
+      }
+    },
+    "node_modules/micromark-util-combine-extensions": {
+      "version": "2.0.1",
+      "resolved": "https://registry.npmjs.org/micromark-util-combine-extensions/-/micromark-util-combine-extensions-2.0.1.tgz",
+      "integrity": "sha512-OnAnH8Ujmy59JcyZw8JSbK9cGpdVY44NKgSM7E9Eh7DiLS2E9RNQf0dONaGDzEG9yjEl5hcqeIsj4hfRkLH/Bg==",
+      "funding": [
+        {
+          "type": "GitHub Sponsors",
+          "url": "https://github.com/sponsors/unifiedjs"
+        },
+        {
+          "type": "OpenCollective",
+          "url": "https://opencollective.com/unified"
+        }
+      ],
+      "license": "MIT",
+      "dependencies": {
+        "micromark-util-chunked": "^2.0.0",
+        "micromark-util-types": "^2.0.0"
+      }
+    },
+    "node_modules/micromark-util-decode-numeric-character-reference": {
+      "version": "2.0.2",
+      "resolved": "https://registry.npmjs.org/micromark-util-decode-numeric-character-reference/-/micromark-util-decode-numeric-character-reference-2.0.2.tgz",
+      "integrity": "sha512-ccUbYk6CwVdkmCQMyr64dXz42EfHGkPQlBj5p7YVGzq8I7CtjXZJrubAYezf7Rp+bjPseiROqe7G6foFd+lEuw==",
+      "funding": [
+        {
+          "type": "GitHub Sponsors",
+          "url": "https://github.com/sponsors/unifiedjs"
+        },
+        {
+          "type": "OpenCollective",
+          "url": "https://opencollective.com/unified"
+        }
+      ],
+      "license": "MIT",
+      "dependencies": {
+        "micromark-util-symbol": "^2.0.0"
+      }
+    },
+    "node_modules/micromark-util-decode-string": {
+      "version": "2.0.1",
+      "resolved": "https://registry.npmjs.org/micromark-util-decode-string/-/micromark-util-decode-string-2.0.1.tgz",
+      "integrity": "sha512-nDV/77Fj6eH1ynwscYTOsbK7rR//Uj0bZXBwJZRfaLEJ1iGBR6kIfNmlNqaqJf649EP0F3NWNdeJi03elllNUQ==",
+      "funding": [
+        {
+          "type": "GitHub Sponsors",
+          "url": "https://github.com/sponsors/unifiedjs"
+        },
+        {
+          "type": "OpenCollective",
+          "url": "https://opencollective.com/unified"
+        }
+      ],
+      "license": "MIT",
+      "dependencies": {
+        "decode-named-character-reference": "^1.0.0",
+        "micromark-util-character": "^2.0.0",
+        "micromark-util-decode-numeric-character-reference": "^2.0.0",
+        "micromark-util-symbol": "^2.0.0"
+      }
+    },
+    "node_modules/micromark-util-encode": {
+      "version": "2.0.1",
+      "resolved": "https://registry.npmjs.org/micromark-util-encode/-/micromark-util-encode-2.0.1.tgz",
+      "integrity": "sha512-c3cVx2y4KqUnwopcO9b/SCdo2O67LwJJ/UyqGfbigahfegL9myoEFoDYZgkT7f36T0bLrM9hZTAaAyH+PCAXjw==",
+      "funding": [
+        {
+          "type": "GitHub Sponsors",
+          "url": "https://github.com/sponsors/unifiedjs"
+        },
+        {
+          "type": "OpenCollective",
+          "url": "https://opencollective.com/unified"
+        }
+      ],
+      "license": "MIT"
+    },
+    "node_modules/micromark-util-html-tag-name": {
+      "version": "2.0.1",
+      "resolved": "https://registry.npmjs.org/micromark-util-html-tag-name/-/micromark-util-html-tag-name-2.0.1.tgz",
+      "integrity": "sha512-2cNEiYDhCWKI+Gs9T0Tiysk136SnR13hhO8yW6BGNyhOC4qYFnwF1nKfD3HFAIXA5c45RrIG1ub11GiXeYd1xA==",
+      "funding": [
+        {
+          "type": "GitHub Sponsors",
+          "url": "https://github.com/sponsors/unifiedjs"
+        },
+        {
+          "type": "OpenCollective",
+          "url": "https://opencollective.com/unified"
+        }
+      ],
+      "license": "MIT"
+    },
+    "node_modules/micromark-util-normalize-identifier": {
+      "version": "2.0.1",
+      "resolved": "https://registry.npmjs.org/micromark-util-normalize-identifier/-/micromark-util-normalize-identifier-2.0.1.tgz",
+      "integrity": "sha512-sxPqmo70LyARJs0w2UclACPUUEqltCkJ6PhKdMIDuJ3gSf/Q+/GIe3WKl0Ijb/GyH9lOpUkRAO2wp0GVkLvS9Q==",
+      "funding": [
+        {
+          "type": "GitHub Sponsors",
+          "url": "https://github.com/sponsors/unifiedjs"
+        },
+        {
+          "type": "OpenCollective",
+          "url": "https://opencollective.com/unified"
+        }
+      ],
+      "license": "MIT",
+      "dependencies": {
+        "micromark-util-symbol": "^2.0.0"
+      }
+    },
+    "node_modules/micromark-util-resolve-all": {
+      "version": "2.0.1",
+      "resolved": "https://registry.npmjs.org/micromark-util-resolve-all/-/micromark-util-resolve-all-2.0.1.tgz",
+      "integrity": "sha512-VdQyxFWFT2/FGJgwQnJYbe1jjQoNTS4RjglmSjTUlpUMa95Htx9NHeYW4rGDJzbjvCsl9eLjMQwGeElsqmzcHg==",
+      "funding": [
+        {
+          "type": "GitHub Sponsors",
+          "url": "https://github.com/sponsors/unifiedjs"
+        },
+        {
+          "type": "OpenCollective",
+          "url": "https://opencollective.com/unified"
+        }
+      ],
+      "license": "MIT",
+      "dependencies": {
+        "micromark-util-types": "^2.0.0"
+      }
+    },
+    "node_modules/micromark-util-sanitize-uri": {
+      "version": "2.0.1",
+      "resolved": "https://registry.npmjs.org/micromark-util-sanitize-uri/-/micromark-util-sanitize-uri-2.0.1.tgz",
+      "integrity": "sha512-9N9IomZ/YuGGZZmQec1MbgxtlgougxTodVwDzzEouPKo3qFWvymFHWcnDi2vzV1ff6kas9ucW+o3yzJK9YB1AQ==",
+      "funding": [
+        {
+          "type": "GitHub Sponsors",
+          "url": "https://github.com/sponsors/unifiedjs"
+        },
+        {
+          "type": "OpenCollective",
+          "url": "https://opencollective.com/unified"
+        }
+      ],
+      "license": "MIT",
+      "dependencies": {
+        "micromark-util-character": "^2.0.0",
+        "micromark-util-encode": "^2.0.0",
+        "micromark-util-symbol": "^2.0.0"
+      }
+    },
+    "node_modules/micromark-util-subtokenize": {
+      "version": "2.1.0",
+      "resolved": "https://registry.npmjs.org/micromark-util-subtokenize/-/micromark-util-subtokenize-2.1.0.tgz",
+      "integrity": "sha512-XQLu552iSctvnEcgXw6+Sx75GflAPNED1qx7eBJ+wydBb2KCbRZe+NwvIEEMM83uml1+2WSXpBAcp9IUCgCYWA==",
+      "funding": [
+        {
+          "type": "GitHub Sponsors",
+          "url": "https://github.com/sponsors/unifiedjs"
+        },
+        {
+          "type": "OpenCollective",
+          "url": "https://opencollective.com/unified"
+        }
+      ],
+      "license": "MIT",
+      "dependencies": {
+        "devlop": "^1.0.0",
+        "micromark-util-chunked": "^2.0.0",
+        "micromark-util-symbol": "^2.0.0",
+        "micromark-util-types": "^2.0.0"
+      }
+    },
+    "node_modules/micromark-util-symbol": {
+      "version": "2.0.1",
+      "resolved": "https://registry.npmjs.org/micromark-util-symbol/-/micromark-util-symbol-2.0.1.tgz",
+      "integrity": "sha512-vs5t8Apaud9N28kgCrRUdEed4UJ+wWNvicHLPxCa9ENlYuAY31M0ETy5y1vA33YoNPDFTghEbnh6efaE8h4x0Q==",
+      "funding": [
+        {
+          "type": "GitHub Sponsors",
+          "url": "https://github.com/sponsors/unifiedjs"
+        },
+        {
+          "type": "OpenCollective",
+          "url": "https://opencollective.com/unified"
+        }
+      ],
+      "license": "MIT"
+    },
+    "node_modules/micromark-util-types": {
+      "version": "2.0.2",
+      "resolved": "https://registry.npmjs.org/micromark-util-types/-/micromark-util-types-2.0.2.tgz",
+      "integrity": "sha512-Yw0ECSpJoViF1qTU4DC6NwtC4aWGt1EkzaQB8KPPyCRR8z9TWeV0HbEFGTO+ZY1wB22zmxnJqhPyTpOVCpeHTA==",
+      "funding": [
+        {
+          "type": "GitHub Sponsors",
+          "url": "https://github.com/sponsors/unifiedjs"
+        },
+        {
+          "type": "OpenCollective",
+          "url": "https://opencollective.com/unified"
+        }
+      ],
+      "license": "MIT"
     },
     "node_modules/mime": {
       "version": "1.6.0",
@@ -3798,8 +4791,7 @@
     "node_modules/ms": {
       "version": "2.1.2",
       "resolved": "https://registry.npmjs.org/ms/-/ms-2.1.2.tgz",
-      "integrity": "sha512-sGkPx+VjMtmA6MX27oA4FBFELFCZZ4S4XqeGOXCv68tT+jb3vk/RyaKWP0PTKyWtmLSM0b+adUTEvbs1PEaH2w==",
-      "dev": true
+      "integrity": "sha512-sGkPx+VjMtmA6MX27oA4FBFELFCZZ4S4XqeGOXCv68tT+jb3vk/RyaKWP0PTKyWtmLSM0b+adUTEvbs1PEaH2w=="
     },
     "node_modules/nanoid": {
       "version": "3.3.7",
@@ -4039,6 +5031,43 @@
         "node": ">=6"
       }
     },
+    "node_modules/parse-entities": {
+      "version": "4.0.2",
+      "resolved": "https://registry.npmjs.org/parse-entities/-/parse-entities-4.0.2.tgz",
+      "integrity": "sha512-GG2AQYWoLgL877gQIKeRPGO1xF9+eG1ujIb5soS5gPvLQ1y2o8FL90w2QWNdf9I361Mpp7726c+lj3U0qK1uGw==",
+      "license": "MIT",
+      "dependencies": {
+        "@types/unist": "^2.0.0",
+        "character-entities-legacy": "^3.0.0",
+        "character-reference-invalid": "^2.0.0",
+        "decode-named-character-reference": "^1.0.0",
+        "is-alphanumerical": "^2.0.0",
+        "is-decimal": "^2.0.0",
+        "is-hexadecimal": "^2.0.0"
+      },
+      "funding": {
+        "type": "github",
+        "url": "https://github.com/sponsors/wooorm"
+      }
+    },
+    "node_modules/parse-entities/node_modules/@types/unist": {
+      "version": "2.0.11",
+      "resolved": "https://registry.npmjs.org/@types/unist/-/unist-2.0.11.tgz",
+      "integrity": "sha512-CmBKiL6NNo/OqgmMn95Fk9Whlp2mtvIv+KNpQKN2F4SjvrEesubTRWGYSg+BnWZOnlCaSTU1sMpsBOzgbYhnsA==",
+      "license": "MIT"
+    },
+    "node_modules/parse5": {
+      "version": "7.3.0",
+      "resolved": "https://registry.npmjs.org/parse5/-/parse5-7.3.0.tgz",
+      "integrity": "sha512-IInvU7fabl34qmi9gY8XOVxhYyMyuH2xUNpb2q8/Y+7552KlejkRvqvD19nMoUW/uQGGbqNpA6Tufu5FL5BZgw==",
+      "license": "MIT",
+      "dependencies": {
+        "entities": "^6.0.0"
+      },
+      "funding": {
+        "url": "https://github.com/inikulin/parse5?sponsor=1"
+      }
+    },
     "node_modules/parseurl": {
       "version": "1.3.3",
       "resolved": "https://registry.npmjs.org/parseurl/-/parseurl-1.3.3.tgz",
@@ -4253,6 +5282,16 @@
         "react": ">=0.14.0"
       }
     },
+    "node_modules/property-information": {
+      "version": "7.2.0",
+      "resolved": "https://registry.npmjs.org/property-information/-/property-information-7.2.0.tgz",
+      "integrity": "sha512-IAtzIB6sUiWaJYrX9smp3V46pBGbBeLFRGdh25kg1334VcBlD8HzhPeNIWQH9zhGmo2itIe25EHt9dQP7G5hmg==",
+      "license": "MIT",
+      "funding": {
+        "type": "github",
+        "url": "https://github.com/sponsors/wooorm"
+      }
+    },
     "node_modules/proxy-addr": {
       "version": "2.0.7",
       "resolved": "https://registry.npmjs.org/proxy-addr/-/proxy-addr-2.0.7.tgz",
@@ -4394,6 +5433,33 @@
       "resolved": "https://registry.npmjs.org/react-lifecycles-compat/-/react-lifecycles-compat-3.0.4.tgz",
       "integrity": "sha512-fBASbA6LnOU9dOU2eW7aQ8xmYBSXUIWr+UmF9b1efZBazGNO+rcXT/icdKnYm2pTwcRylVUYwW7H1PHfLekVzA=="
     },
+    "node_modules/react-markdown": {
+      "version": "10.1.0",
+      "resolved": "https://registry.npmjs.org/react-markdown/-/react-markdown-10.1.0.tgz",
+      "integrity": "sha512-qKxVopLT/TyA6BX3Ue5NwabOsAzm0Q7kAPwq6L+wWDwisYs7R8vZ0nRXqq6rkueboxpkjvLGU9fWifiX/ZZFxQ==",
+      "license": "MIT",
+      "dependencies": {
+        "@types/hast": "^3.0.0",
+        "@types/mdast": "^4.0.0",
+        "devlop": "^1.0.0",
+        "hast-util-to-jsx-runtime": "^2.0.0",
+        "html-url-attributes": "^3.0.0",
+        "mdast-util-to-hast": "^13.0.0",
+        "remark-parse": "^11.0.0",
+        "remark-rehype": "^11.0.0",
+        "unified": "^11.0.0",
+        "unist-util-visit": "^5.0.0",
+        "vfile": "^6.0.0"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/unified"
+      },
+      "peerDependencies": {
+        "@types/react": ">=18",
+        "react": ">=18"
+      }
+    },
     "node_modules/react-refresh": {
       "version": "0.14.0",
       "resolved": "https://registry.npmjs.org/react-refresh/-/react-refresh-0.14.0.tgz",
@@ -4511,6 +5577,54 @@
       },
       "funding": {
         "url": "https://github.com/sponsors/ljharb"
+      }
+    },
+    "node_modules/rehype-raw": {
+      "version": "7.0.0",
+      "resolved": "https://registry.npmjs.org/rehype-raw/-/rehype-raw-7.0.0.tgz",
+      "integrity": "sha512-/aE8hCfKlQeA8LmyeyQvQF3eBiLRGNlfBJEvWH7ivp9sBqs7TNqBL5X3v157rM4IFETqDnIOO+z5M/biZbo9Ww==",
+      "license": "MIT",
+      "dependencies": {
+        "@types/hast": "^3.0.0",
+        "hast-util-raw": "^9.0.0",
+        "vfile": "^6.0.0"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/unified"
+      }
+    },
+    "node_modules/remark-parse": {
+      "version": "11.0.0",
+      "resolved": "https://registry.npmjs.org/remark-parse/-/remark-parse-11.0.0.tgz",
+      "integrity": "sha512-FCxlKLNGknS5ba/1lmpYijMUzX2esxW5xQqjWxw2eHFfS2MSdaHVINFmhjo+qN1WhZhNimq0dZATN9pH0IDrpA==",
+      "license": "MIT",
+      "dependencies": {
+        "@types/mdast": "^4.0.0",
+        "mdast-util-from-markdown": "^2.0.0",
+        "micromark-util-types": "^2.0.0",
+        "unified": "^11.0.0"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/unified"
+      }
+    },
+    "node_modules/remark-rehype": {
+      "version": "11.1.2",
+      "resolved": "https://registry.npmjs.org/remark-rehype/-/remark-rehype-11.1.2.tgz",
+      "integrity": "sha512-Dh7l57ianaEoIpzbp0PC9UKAdCSVklD8E5Rpw7ETfbTl3FqcOOgq5q2LVDhgGCkaBv7p24JXikPdvhhmHvKMsw==",
+      "license": "MIT",
+      "dependencies": {
+        "@types/hast": "^3.0.0",
+        "@types/mdast": "^4.0.0",
+        "mdast-util-to-hast": "^13.0.0",
+        "unified": "^11.0.0",
+        "vfile": "^6.0.0"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/unified"
       }
     },
     "node_modules/resolve": {
@@ -4839,6 +5953,16 @@
         "node": ">=0.10.0"
       }
     },
+    "node_modules/space-separated-tokens": {
+      "version": "2.0.2",
+      "resolved": "https://registry.npmjs.org/space-separated-tokens/-/space-separated-tokens-2.0.2.tgz",
+      "integrity": "sha512-PEGlAwrG8yXGXRjW32fGbg66JAlOAwbObuqVoJpv/mRgoWDQfgH1wDPvtzWyUSNAXBGSk8h755YDbbcEy3SH2Q==",
+      "license": "MIT",
+      "funding": {
+        "type": "github",
+        "url": "https://github.com/sponsors/wooorm"
+      }
+    },
     "node_modules/statuses": {
       "version": "2.0.1",
       "resolved": "https://registry.npmjs.org/statuses/-/statuses-2.0.1.tgz",
@@ -4912,6 +6036,20 @@
         "url": "https://github.com/sponsors/ljharb"
       }
     },
+    "node_modules/stringify-entities": {
+      "version": "4.0.4",
+      "resolved": "https://registry.npmjs.org/stringify-entities/-/stringify-entities-4.0.4.tgz",
+      "integrity": "sha512-IwfBptatlO+QCJUo19AqvrPNqlVMpW9YEL2LIVY+Rpv2qsjCGxaDLNRgeGsQWJhfItebuJhsGSLjaBbNSQ+ieg==",
+      "license": "MIT",
+      "dependencies": {
+        "character-entities-html4": "^2.0.0",
+        "character-entities-legacy": "^3.0.0"
+      },
+      "funding": {
+        "type": "github",
+        "url": "https://github.com/sponsors/wooorm"
+      }
+    },
     "node_modules/strip-ansi": {
       "version": "6.0.1",
       "resolved": "https://registry.npmjs.org/strip-ansi/-/strip-ansi-6.0.1.tgz",
@@ -4946,6 +6084,24 @@
       },
       "engines": {
         "node": ">=0.10.0"
+      }
+    },
+    "node_modules/style-to-js": {
+      "version": "1.1.21",
+      "resolved": "https://registry.npmjs.org/style-to-js/-/style-to-js-1.1.21.tgz",
+      "integrity": "sha512-RjQetxJrrUJLQPHbLku6U/ocGtzyjbJMP9lCNK7Ag0CNh690nSH8woqWH9u16nMjYBAok+i7JO1NP2pOy8IsPQ==",
+      "license": "MIT",
+      "dependencies": {
+        "style-to-object": "1.0.14"
+      }
+    },
+    "node_modules/style-to-object": {
+      "version": "1.0.14",
+      "resolved": "https://registry.npmjs.org/style-to-object/-/style-to-object-1.0.14.tgz",
+      "integrity": "sha512-LIN7rULI0jBscWQYaSswptyderlarFkjQ+t79nzty8tcIAceVomEVlLzH5VP4Cmsv6MtKhs7qaAiwlcp+Mgaxw==",
+      "license": "MIT",
+      "dependencies": {
+        "inline-style-parser": "0.2.7"
       }
     },
     "node_modules/supports-color": {
@@ -4995,6 +6151,16 @@
         "node": ">=0.6"
       }
     },
+    "node_modules/trim-lines": {
+      "version": "3.0.1",
+      "resolved": "https://registry.npmjs.org/trim-lines/-/trim-lines-3.0.1.tgz",
+      "integrity": "sha512-kRj8B+YHZCc9kQYdWfJB2/oUl9rA99qbowYYBtr4ui4mZyAQ2JpvVBd/6U2YloATfqBhBTSMhTpgBHtU0Mf3Rg==",
+      "license": "MIT",
+      "funding": {
+        "type": "github",
+        "url": "https://github.com/sponsors/wooorm"
+      }
+    },
     "node_modules/trim-repeated": {
       "version": "1.0.0",
       "resolved": "https://registry.npmjs.org/trim-repeated/-/trim-repeated-1.0.0.tgz",
@@ -5005,6 +6171,16 @@
       },
       "engines": {
         "node": ">=0.10.0"
+      }
+    },
+    "node_modules/trough": {
+      "version": "2.2.0",
+      "resolved": "https://registry.npmjs.org/trough/-/trough-2.2.0.tgz",
+      "integrity": "sha512-tmMpK00BjZiUyVyvrBK7knerNgmgvcV/KLVyuma/SC+TQN167GrMRciANTz09+k3zW8L8t60jWO1GpfkZdjTaw==",
+      "license": "MIT",
+      "funding": {
+        "type": "github",
+        "url": "https://github.com/sponsors/wooorm"
       }
     },
     "node_modules/tslib": {
@@ -5150,6 +6326,93 @@
         "react": ">=15.0.0"
       }
     },
+    "node_modules/unified": {
+      "version": "11.0.5",
+      "resolved": "https://registry.npmjs.org/unified/-/unified-11.0.5.tgz",
+      "integrity": "sha512-xKvGhPWw3k84Qjh8bI3ZeJjqnyadK+GEFtazSfZv/rKeTkTjOJho6mFqh2SM96iIcZokxiOpg78GazTSg8+KHA==",
+      "license": "MIT",
+      "dependencies": {
+        "@types/unist": "^3.0.0",
+        "bail": "^2.0.0",
+        "devlop": "^1.0.0",
+        "extend": "^3.0.0",
+        "is-plain-obj": "^4.0.0",
+        "trough": "^2.0.0",
+        "vfile": "^6.0.0"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/unified"
+      }
+    },
+    "node_modules/unist-util-is": {
+      "version": "6.0.1",
+      "resolved": "https://registry.npmjs.org/unist-util-is/-/unist-util-is-6.0.1.tgz",
+      "integrity": "sha512-LsiILbtBETkDz8I9p1dQ0uyRUWuaQzd/cuEeS1hoRSyW5E5XGmTzlwY1OrNzzakGowI9Dr/I8HVaw4hTtnxy8g==",
+      "license": "MIT",
+      "dependencies": {
+        "@types/unist": "^3.0.0"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/unified"
+      }
+    },
+    "node_modules/unist-util-position": {
+      "version": "5.0.0",
+      "resolved": "https://registry.npmjs.org/unist-util-position/-/unist-util-position-5.0.0.tgz",
+      "integrity": "sha512-fucsC7HjXvkB5R3kTCO7kUjRdrS0BJt3M/FPxmHMBOm8JQi2BsHAHFsy27E0EolP8rp0NzXsJ+jNPyDWvOJZPA==",
+      "license": "MIT",
+      "dependencies": {
+        "@types/unist": "^3.0.0"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/unified"
+      }
+    },
+    "node_modules/unist-util-stringify-position": {
+      "version": "4.0.0",
+      "resolved": "https://registry.npmjs.org/unist-util-stringify-position/-/unist-util-stringify-position-4.0.0.tgz",
+      "integrity": "sha512-0ASV06AAoKCDkS2+xw5RXJywruurpbC4JZSm7nr7MOt1ojAzvyyaO+UxZf18j8FCF6kmzCZKcAgN/yu2gm2XgQ==",
+      "license": "MIT",
+      "dependencies": {
+        "@types/unist": "^3.0.0"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/unified"
+      }
+    },
+    "node_modules/unist-util-visit": {
+      "version": "5.1.0",
+      "resolved": "https://registry.npmjs.org/unist-util-visit/-/unist-util-visit-5.1.0.tgz",
+      "integrity": "sha512-m+vIdyeCOpdr/QeQCu2EzxX/ohgS8KbnPDgFni4dQsfSCtpz8UqDyY5GjRru8PDKuYn7Fq19j1CQ+nJSsGKOzg==",
+      "license": "MIT",
+      "dependencies": {
+        "@types/unist": "^3.0.0",
+        "unist-util-is": "^6.0.0",
+        "unist-util-visit-parents": "^6.0.0"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/unified"
+      }
+    },
+    "node_modules/unist-util-visit-parents": {
+      "version": "6.0.2",
+      "resolved": "https://registry.npmjs.org/unist-util-visit-parents/-/unist-util-visit-parents-6.0.2.tgz",
+      "integrity": "sha512-goh1s1TBrqSqukSc8wrjwWhL0hiJxgA8m4kFxGlQ+8FYQ3C/m11FcTs4YYem7V664AhHVvgoQLk890Ssdsr2IQ==",
+      "license": "MIT",
+      "dependencies": {
+        "@types/unist": "^3.0.0",
+        "unist-util-is": "^6.0.0"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/unified"
+      }
+    },
     "node_modules/universalify": {
       "version": "2.0.1",
       "resolved": "https://registry.npmjs.org/universalify/-/universalify-2.0.1.tgz",
@@ -5222,6 +6485,48 @@
         "node": ">= 0.8"
       }
     },
+    "node_modules/vfile": {
+      "version": "6.0.3",
+      "resolved": "https://registry.npmjs.org/vfile/-/vfile-6.0.3.tgz",
+      "integrity": "sha512-KzIbH/9tXat2u30jf+smMwFCsno4wHVdNmzFyL+T/L3UGqqk6JKfVqOFOZEpZSHADH1k40ab6NUIXZq422ov3Q==",
+      "license": "MIT",
+      "dependencies": {
+        "@types/unist": "^3.0.0",
+        "vfile-message": "^4.0.0"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/unified"
+      }
+    },
+    "node_modules/vfile-location": {
+      "version": "5.0.3",
+      "resolved": "https://registry.npmjs.org/vfile-location/-/vfile-location-5.0.3.tgz",
+      "integrity": "sha512-5yXvWDEgqeiYiBe1lbxYF7UMAIm/IcopxMHrMQDq3nvKcjPKIhZklUKL+AE7J7uApI4kwe2snsK+eI6UTj9EHg==",
+      "license": "MIT",
+      "dependencies": {
+        "@types/unist": "^3.0.0",
+        "vfile": "^6.0.0"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/unified"
+      }
+    },
+    "node_modules/vfile-message": {
+      "version": "4.0.3",
+      "resolved": "https://registry.npmjs.org/vfile-message/-/vfile-message-4.0.3.tgz",
+      "integrity": "sha512-QTHzsGd1EhbZs4AsQ20JX1rC3cOlt/IWJruk893DfLRr57lcnOeMaWG4K0JrRta4mIJZKth2Au3mM3u03/JWKw==",
+      "license": "MIT",
+      "dependencies": {
+        "@types/unist": "^3.0.0",
+        "unist-util-stringify-position": "^4.0.0"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/unified"
+      }
+    },
     "node_modules/vite": {
       "version": "5.1.5",
       "resolved": "https://registry.npmjs.org/vite/-/vite-5.1.5.tgz",
@@ -5284,6 +6589,16 @@
       "integrity": "sha512-rpJyN222KWIvHJ/F53XSZv0Zl/accqHR8et1kpaMTD/fLCRxtV8iX8czMzY7sVZupTI3zcUTg8eycS2kNF9l6w==",
       "dependencies": {
         "loose-envify": "^1.0.0"
+      }
+    },
+    "node_modules/web-namespaces": {
+      "version": "2.0.1",
+      "resolved": "https://registry.npmjs.org/web-namespaces/-/web-namespaces-2.0.1.tgz",
+      "integrity": "sha512-bKr1DkiNa2krS7qxNtdrtHAmzuYGFQLiQ13TsorsdT6ULTkPLKuu5+GsFpDlg6JFjUTwX2DyhMPG2be8uPrqsQ==",
+      "license": "MIT",
+      "funding": {
+        "type": "github",
+        "url": "https://github.com/sponsors/wooorm"
       }
     },
     "node_modules/which": {
@@ -5399,6 +6714,16 @@
       },
       "funding": {
         "url": "https://github.com/sponsors/sindresorhus"
+      }
+    },
+    "node_modules/zwitch": {
+      "version": "2.0.4",
+      "resolved": "https://registry.npmjs.org/zwitch/-/zwitch-2.0.4.tgz",
+      "integrity": "sha512-bXE4cR/kVZhKZX/RjPEflHaKVhUVl85noU3v6b8apfQEc1x4A+zBxjZ4lN8LqGd6WZ3dl98pY4o717VFmoPp+A==",
+      "license": "MIT",
+      "funding": {
+        "type": "github",
+        "url": "https://github.com/sponsors/wooorm"
       }
     }
   }

--- a/package.json
+++ b/package.json
@@ -26,7 +26,9 @@
     "react": "^18.2.0",
     "react-bootstrap": "^2.10.1",
     "react-dom": "^18.2.0",
-    "react-router-dom": "^7.18.0"
+    "react-markdown": "^10.1.0",
+    "react-router-dom": "^7.18.0",
+    "rehype-raw": "^7.0.0"
   },
   "devDependencies": {
     "@types/jquery": "^3.5.29",

--- a/src/content/112maze.md
+++ b/src/content/112maze.md
@@ -1,11 +1,32 @@
-A 15-112 term project: a maze game that uses raycasting to render 3D visuals. The objective is to collect a key and reach the end of the maze, with key and enemy placements randomized on every run.
-
-Difficulty increases as you progress, with longer mazes built with different maze-generation algorithms and enemies driven by different pathfinding algorithms. A toggleable minimap, a path-hint that reveals the way to the next objective, and full camera controls round out the game.
+A 15-112 term project: a maze game that uses raycasting to render 3D visuals. The objective is to collect a key and reach the end of the maze, with key and enemy placements randomized on every run. Difficulty increases as you progress, with longer mazes built with different maze-generation algorithms and enemies driven by different pathfinding algorithms. A toggleable minimap, a path-hint that reveals the way to the next objective, and full camera controls round out the game.
 
 ## Features
 
-- 3D visuals rendered with raycasting
-- Multiple maze-generation algorithms as levels progress
-- Enemies driven by different pathfinding algorithms
+- 3D visuals rendered with per-column DDA raycasting
+- Multiple maze-generation algorithms as levels progress: recursive DFS, randomized Prim's, and randomized Kruskal's
+- Enemies driven by different pathfinding algorithms (recursive DFS and BFS)
 - Path hints to the next objective and a toggleable minimap
 - Randomized key and enemy placement every run
+
+## Implementation details
+
+### Rendering with DDA raycasting
+
+The 3D view is drawn one vertical strip at a time. For every column of the screen, a ray is cast from the player through the camera plane, and a Digital Differential Analysis (DDA) walk finds the first wall it hits. Instead of inching the ray forward in small fixed steps (which is slow and can tunnel straight through wall corners), DDA exploits the fact that the maze is a uniform grid: from the ray's direction it precomputes how far the ray travels between consecutive x-gridlines and between consecutive y-gridlines, then repeatedly jumps to whichever gridline crossing is nearer. Each iteration advances exactly one cell, so the ray visits every cell it passes through and a hit can never be missed, no matter how thin the wall.
+
+When the ray lands in a wall cell, the perpendicular distance to the wall, rather than the raw Euclidean distance, sets the height of the wall slice for that column, which avoids the fisheye distortion you'd otherwise get at the edges of the screen. Walls hit on an x-gridline are shaded differently from walls hit on a y-gridline, giving the corridors a cheap but convincing sense of depth. Since the cost is one DDA walk per screen column regardless of maze size, the renderer stays fast even as later levels grow.
+
+### Maze generation
+
+Each maze is a grid of cells that starts fully walled, and a generation algorithm decides which walls to knock down. All three produce a perfect maze (every cell reachable, exactly one path between any two cells), but each has a distinct character, so the level's algorithm changes how the maze feels to navigate:
+
+- **Recursive DFS (recursive backtracker)**: walks from cell to random unvisited neighbor, carving as it goes, and backtracks up the recursion stack when it dead-ends. The depth-first bias produces long, winding corridors with relatively few branches.
+- **Randomized Prim's**: grows the maze outward from a starting cell, repeatedly picking a random frontier wall and carving into the unvisited cell behind it. The result branches heavily, with lots of short dead ends off a bushy core.
+- **Randomized Kruskal's**: treats every cell as its own set, shuffles the full list of interior walls, and removes a wall only when the cells on either side belong to different sets (tracked with union-find, which also guarantees no cycles). Because walls are considered in uniformly random order, the texture is even across the whole maze rather than biased toward any starting point.
+
+### Enemy pathfinding
+
+Enemies chase the player by pathfinding through the same grid, and different enemies run different algorithms:
+
+- **Recursive DFS** finds *a* route to the player quickly, but not necessarily a short one. These enemies take meandering, unpredictable paths through the maze.
+- **BFS** explores outward level by level, so the path it returns is guaranteed shortest, so these enemies beeline for the player, making them the more dangerous of the two.

--- a/src/content/112maze.md
+++ b/src/content/112maze.md
@@ -1,0 +1,11 @@
+A 15-112 term project: a maze game that uses raycasting to render 3D visuals. The objective is to collect a key and reach the end of the maze, with key and enemy placements randomized on every run.
+
+Difficulty increases as you progress, with longer mazes built with different maze-generation algorithms and enemies driven by different pathfinding algorithms. A toggleable minimap, a path-hint that reveals the way to the next objective, and full camera controls round out the game.
+
+## Features
+
+- 3D visuals rendered with raycasting
+- Multiple maze-generation algorithms as levels progress
+- Enemies driven by different pathfinding algorithms
+- Path hints to the next objective and a toggleable minimap
+- Randomized key and enemy placement every run

--- a/src/content/fraud-detection.md
+++ b/src/content/fraud-detection.md
@@ -1,0 +1,10 @@
+A machine learning project exploring different models and proper handling of heavily imbalanced data to detect fraudulent credit card transactions, built on a public fraud-detection dataset from Kaggle.
+
+After exploratory data analysis to identify patterns between features, the class imbalance was addressed with SMOTE oversampling and Tomek Links undersampling. Random Forest, AdaBoost, and XGBoost models were trained and compared, and the results were analyzed with SHAP values to understand feature importance and relationships.
+
+## Features
+
+- Exploratory data analysis of transaction patterns
+- SMOTE and Tomek Links to handle imbalanced classes
+- Random Forest, AdaBoost, and XGBoost model comparison
+- SHAP value analysis of feature importance

--- a/src/content/fraud-detection.md
+++ b/src/content/fraud-detection.md
@@ -1,10 +1,22 @@
-A machine learning project exploring different models and proper handling of heavily imbalanced data to detect fraudulent credit card transactions, built on a public fraud-detection dataset from Kaggle.
-
-After exploratory data analysis to identify patterns between features, the class imbalance was addressed with SMOTE oversampling and Tomek Links undersampling. Random Forest, AdaBoost, and XGBoost models were trained and compared, and the results were analyzed with SHAP values to understand feature importance and relationships.
+A machine learning project exploring how to detect fraud in heavily imbalanced data, built on a public Kaggle dataset of 1.3M credit card transactions where only 0.58% are fraudulent. The full pipeline lives in a Jupyter notebook (EDA, preprocessing, feature selection, resampling, hyperparameter tuning, and evaluation), and the trained models ship in a Streamlit app that scores individual transactions and explains each prediction with SHAP.
 
 ## Features
 
-- Exploratory data analysis of transaction patterns
-- SMOTE and Tomek Links to handle imbalanced classes
-- Random Forest, AdaBoost, and XGBoost model comparison
-- SHAP value analysis of feature importance
+- End-to-end notebook pipeline: EDA, preprocessing, feature selection, resampling, tuning, evaluation
+- SMOTE + Tomek Links resampling on the training split only, with a time-based train/validation/test split to prevent leakage
+- Random Forest, AdaBoost, and XGBoost compared, tuned with Optuna to optimize F1 on the fraud class
+- SHAP-driven feature analysis that fed back into feature engineering
+- Streamlit app with an interactive fraud checker, per-prediction TreeSHAP waterfall explanations, and EDA/model-comparison charts
+- Dockerized deployment that ships model bundles and precomputed aggregates instead of the full dataset
+
+## Implementation details
+
+Exploratory analysis surfaced the patterns the models end up leaning on: fraudulent transactions have a far higher median amount than genuine ones ($396 vs. $47) and cluster in late-night hours. Permutation importance narrowed the feature set to merchant category, log-transformed amount, gender, city population, cardholder age, and hour of day. Three tree-based models (Random Forest, AdaBoost, and XGBoost) were tuned with Optuna to maximize F1 on the fraud class and compared on a held-out test set.
+
+### Class imbalance and leakage-safe evaluation
+
+With 99.4% genuine transactions, a model that never predicts fraud scores 99.4% accuracy, so accuracy is nearly meaningless here. The imbalance is handled with combined SMOTE oversampling and Tomek Links undersampling, applied to the training split only so no synthetic samples leak into evaluation. The train/validation/test split is done by time rather than randomly: the test set is the most recent ~2 months of transactions (150,481 rows, 948 fraud) that the models never saw, mimicking how a fraud model actually gets deployed against future data. On that test set Random Forest reached 0.959 precision / 0.800 recall (F1 0.872) and XGBoost 0.887 / 0.841 (F1 0.863), while AdaBoost fell far behind at 0.379 F1.
+
+### Explaining predictions with SHAP
+
+SHAP is used in both directions: in the notebook, beeswarm plots of TreeSHAP values are compared against XGBoost's built-in importances, which revealed that gender contributed little on its own and motivated engineering a combined gender-age feature. In the Streamlit app, every XGBoost prediction comes with a live waterfall chart of exact TreeSHAP contributions in log-odds, showing which inputs pushed the transaction toward fraud or genuine. The app itself ships only the small serialized model bundles and precomputed EDA aggregates — never the raw CSV — and runs in Docker.

--- a/src/content/game-embeddings.md
+++ b/src/content/game-embeddings.md
@@ -1,10 +1,22 @@
-Steam game descriptions are embedded with a Sentence Transformer and visualized using multiple dimension reduction techniques, including PCA, t-SNE, and PaCMAP, to explore how games cluster by their content.
-
-The model is also fine-tuned on a variety of generated queries so that games can be searched by genre, and LIME is used to explain which parts of a query and description led to a game being matched. The data comes from the Steam Games Dataset on Kaggle.
+Semantic search over the Steam catalog: describe the mechanics, mood, or setting you want in plain language, and the app returns the closest games in embedding space — then shows *why* each one matched and *where* it sits on a map of the whole catalog. Games come from the Steam Games Dataset on Kaggle; each one is condensed into a "profile" (its store description plus tags and features, with acronyms like FPS and MMORPG expanded to full phrases so the language model actually sees the words) and embedded with a Sentence Transformer.
 
 ## Features
 
-- Sentence Transformer (SBERT) embeddings of game descriptions
-- Visualizations with PCA, t-SNE, and PaCMAP dimension reduction
-- Fine-tuned on generated queries to support genre-based game search
-- LIME explanations for why a game matches a search query
+- Natural-language game search ranked by cosine similarity over a ChromaDB vector index
+- `all-mpnet-base-v2` fine-tuned on synthetic tag- and title-derived queries with `MultipleNegativesRankingLoss`
+- LIME attributions showing which words of the query or the game's profile drove a match
+- Interactive PCA, t-SNE, and PaCMAP maps of the catalog with KMeans clusters, and live queries projected out-of-sample onto them
+- Offline index build (embeddings, vector index, projections) so the app stays fast per request
+- Multi-page Streamlit app with a pytest suite, Dockerized and deployed to Streamlit Community Cloud
+
+## Implementation details
+
+The pipeline splits into an offline build and a live app. A build script embeds every profile with a fine-tuned `all-mpnet-base-v2` model, writes them into a ChromaDB vector index (cosine similarity over an HNSW graph), and precomputes PCA, t-SNE, and PaCMAP projections of the catalog with KMeans cluster labels. The multi-page Streamlit app (Search, Explain, Visualize, Catalog) then only has to encode the user's query at request time. It runs in Docker (the index is baked in at image build) and is deployed on Streamlit Community Cloud, with the fine-tuned model published to the Hugging Face Hub as its fallback source.
+
+### Fine-tuning without real search logs
+
+Off the shelf, MPNet embeds polished store descriptions and terse user queries into rather different regions of space, and there is no dataset of real "what players typed → what they meant" pairs to fix that. So the training data is synthesized: for each game, random subsets of its tags and features are sampled, shuffled, and joined into short lowercase queries ("roguelike deckbuilder game"), in both acronym and expanded forms, alongside casing and punctuation variants of the title itself. The model is then fine-tuned on 10,000 of these query→profile pairs with `MultipleNegativesRankingLoss`, which treats every other profile in a batch as a negative, pulling a game's plausible queries toward its profile without any hand labeling.
+
+### Explaining and mapping the matches
+
+Similarity scores alone are opaque, so the Explain page wraps the embedding model in LIME: it perturbs the query text word by word, re-embeds each variant, and measures how the cosine similarity to the matched game moves, surfacing which words actually drove the match. The same attribution runs in the other direction over the game's profile. On the Visualize page, the catalog is shown as interactive Plotly scatter plots (3D for PCA, 2D for t-SNE and PaCMAP) colored by cluster, and because openTSNE and PaCMAP support out-of-sample projection from their saved fits, a live query can be dropped onto the precomputed map as a marker to see which neighborhood of game-space it lands in.

--- a/src/content/game-embeddings.md
+++ b/src/content/game-embeddings.md
@@ -1,0 +1,10 @@
+Steam game descriptions are embedded with a Sentence Transformer and visualized using multiple dimension reduction techniques, including PCA, t-SNE, and PaCMAP, to explore how games cluster by their content.
+
+The model is also fine-tuned on a variety of generated queries so that games can be searched by genre, and LIME is used to explain which parts of a query and description led to a game being matched. The data comes from the Steam Games Dataset on Kaggle.
+
+## Features
+
+- Sentence Transformer (SBERT) embeddings of game descriptions
+- Visualizations with PCA, t-SNE, and PaCMAP dimension reduction
+- Fine-tuned on generated queries to support genre-based game search
+- LIME explanations for why a game matches a search query

--- a/src/content/hollow-knight-bot.md
+++ b/src/content/hollow-knight-bot.md
@@ -1,0 +1,14 @@
+A PPO agent that fights Hornet (Hall of Gods, Attuned) inside the actual game, with no emulator or pixel input. A custom C# mod runs inside Hollow Knight and exposes a TCP bridge: the trainer sends button presses, the mod holds them for one 67 ms tick, samples the game state (positions, velocities, HP, SOUL, Hornet's FSM state), and replies. The agent decides at 15 Hz among 21 discrete moves, and because buttons stay held across repeated steps, jump height, healing, and nail-art charging are all emergent behaviors.
+
+The mod drives every episode reset itself: from a fresh boot it navigates the title menu, stands up from the Hall of Gods bench, runs to the statue, and starts the fight with no human input. On the Python side, a Gymnasium environment wraps the bridge, and a supervisor layer makes training fault-tolerant end to end. It launches and owns the game process, reconnects through resets, and relaunches the game if it wedges or crashes, so an overnight run survives anything short of a power cut.
+
+Training scales to multiple game instances in parallel, each a slot of the same vectorized PPO with its own copy-on-write app clone for save isolation and a keepalive pinger to hold connections through lockstep gaps. A web dashboard tracks every run (learning curves, win rate, steps/hour, ETA) and can start, resume, and stop training itself. Checkpoints every 15k steps mean a crash never loses more than about 17 minutes of progress.
+
+## Features
+
+- C# game mod with a TCP bridge that runs the real game in 67 ms lockstep with the trainer
+- Fully automated episode resets: the mod boots the game from title screen to boss fight with no human input
+- Fault-tolerant training supervisor that relaunches crashed or wedged game processes and resumes mid-run
+- Multi-instance training with per-instance save sandboxes (APFS copy-on-write app clones) for roughly N-times sample throughput
+- Web dashboard that launches, monitors, and stops runs, with per-generation learning curves and live episode rewards
+- Checkpointed "generations" with full resume (weights plus observation-normalization stats) and replay of any checkpoint

--- a/src/content/hollow-knight-bot.md
+++ b/src/content/hollow-knight-bot.md
@@ -1,9 +1,5 @@
 A PPO agent that fights Hornet (Hall of Gods, Attuned) inside the actual game, with no emulator or pixel input. A custom C# mod runs inside Hollow Knight and exposes a TCP bridge: the trainer sends button presses, the mod holds them for one 67 ms tick, samples the game state (positions, velocities, HP, SOUL, Hornet's FSM state), and replies. The agent decides at 15 Hz among 21 discrete moves, and because buttons stay held across repeated steps, jump height, healing, and nail-art charging are all emergent behaviors.
 
-The mod drives every episode reset itself: from a fresh boot it navigates the title menu, stands up from the Hall of Gods bench, runs to the statue, and starts the fight with no human input. On the Python side, a Gymnasium environment wraps the bridge, and a supervisor layer makes training fault-tolerant end to end. It launches and owns the game process, reconnects through resets, and relaunches the game if it wedges or crashes, so an overnight run survives anything short of a power cut.
-
-Training scales to multiple game instances in parallel, each a slot of the same vectorized PPO with its own copy-on-write app clone for save isolation and a keepalive pinger to hold connections through lockstep gaps. A web dashboard tracks every run (learning curves, win rate, steps/hour, ETA) and can start, resume, and stop training itself. Checkpoints every 15k steps mean a crash never loses more than about 17 minutes of progress.
-
 ## Features
 
 - C# game mod with a TCP bridge that runs the real game in 67 ms lockstep with the trainer
@@ -12,3 +8,9 @@ Training scales to multiple game instances in parallel, each a slot of the same 
 - Multi-instance training with per-instance save sandboxes (APFS copy-on-write app clones) for roughly N-times sample throughput
 - Web dashboard that launches, monitors, and stops runs, with per-generation learning curves and live episode rewards
 - Checkpointed "generations" with full resume (weights plus observation-normalization stats) and replay of any checkpoint
+
+## Implementation details
+
+The mod drives every episode reset itself: from a fresh boot it navigates the title menu, stands up from the Hall of Gods bench, runs to the statue, and starts the fight with no human input. On the Python side, a Gymnasium environment wraps the bridge, and a supervisor layer makes training fault-tolerant end to end. It launches and owns the game process, reconnects through resets, and relaunches the game if it wedges or crashes, so an overnight run survives anything short of a power cut.
+
+Training scales to multiple game instances in parallel, each a slot of the same vectorized PPO with its own copy-on-write app clone for save isolation and a keepalive pinger to hold connections through lockstep gaps. A web dashboard tracks every run (learning curves, win rate, steps/hour, ETA) and can start, resume, and stop training itself. Checkpoints every 15k steps mean a crash never loses more than about 17 minutes of progress.

--- a/src/content/integrity-check.md
+++ b/src/content/integrity-check.md
@@ -1,0 +1,10 @@
+A command line tool that verifies the integrity of files by computing cryptographic hashes with SHA-256 and comparing them against a stored baseline. It accepts either a single log file or an entire directory, and clearly reports any discrepancies that indicate possible file tampering.
+
+The tool works in three modes: init computes and securely stores the hashes of the given file or directory, check re-computes them and compares against the stored baseline, and update re-initializes the baseline after intentional changes.
+
+## Features
+
+- Accepts a single file or an entire directory as input
+- Computes SHA-256 hashes and stores them securely on first use
+- Reports discrepancies that indicate possible file tampering
+- init / check / update commands for initializing, verifying, and re-baselining hashes

--- a/src/content/integrity-check.md
+++ b/src/content/integrity-check.md
@@ -1,10 +1,22 @@
-A command line tool that verifies the integrity of files by computing cryptographic hashes with SHA-256 and comparing them against a stored baseline. It accepts either a single log file or an entire directory, and clearly reports any discrepancies that indicate possible file tampering.
-
-The tool works in three modes: init computes and securely stores the hashes of the given file or directory, check re-computes them and compares against the stored baseline, and update re-initializes the baseline after intentional changes.
+A Rust command-line tool that detects file tampering by fingerprinting files with SHA-256 and comparing them against a stored baseline. It accepts either a single log file or a whole directory, and works in three modes: `init` computes and stores the hashes of every file given, `check` re-computes them and reports per file whether it is unchanged or has been modified, and `update` re-baselines after intentional changes.
 
 ## Features
 
-- Accepts a single file or an entire directory as input
-- Computes SHA-256 hashes and stores them securely on first use
-- Reports discrepancies that indicate possible file tampering
-- init / check / update commands for initializing, verifying, and re-baselining hashes
+- `init` / `check` / `update` subcommands for baselining, verifying, and re-baselining
+- Accepts a single file or an entire directory of files as input
+- SHA-256 digests computed incrementally through a buffered reader
+- Baseline persisted in a SQLite database keyed by file path
+- Per-file verdicts on check: unchanged, modified, or missing from the baseline (an error, not a pass)
+- Library/binary split with an integration test suite run against tempdir-isolated fixtures
+
+## Implementation details
+
+The CLI is built on clap's derive parser, and every fallible step carries an `anyhow` context, so failures surface as readable chains ("could not open file X") rather than bare I/O errors. Hashes are computed by streaming each file through a buffered reader into an incremental SHA-256 hasher, so a file is never loaded into memory whole; the digest accumulates as bytes come off disk and is finalized into a hex string at the end.
+
+### The SQLite baseline
+
+Rather than a flat text file, the baseline lives in a local SQLite database with a single `file_hashes` table mapping each file's path (the primary key) to its hex-encoded digest. The schema is created idempotently on every open (`CREATE TABLE IF NOT EXISTS`), so `init`, `check`, and `update` all work against a fresh or existing database without a separate setup step, and loading an empty baseline simply yields an empty map.
+
+On `check`, the entire baseline is read into an in-memory map keyed by path, then each file on disk is re-hashed and looked up against it. A digest mismatch is reported as a modification; a file with no stored hash at all is treated as an error rather than silently passing, so an attacker can't evade detection by swapping in a file the baseline has never seen. `update` goes the other direction: it loads the stored map, recomputes the digest for each target file, and writes the merged result back.
+
+The hashing, storage, and comparison logic all live in a library crate that the thin CLI binary calls into. That split makes the core testable in isolation: an integration test suite exercises the round trip (hash, store, load, compare, update) against temporary directories and scratch databases, including the tamper case where a file's contents change between baseline and check.

--- a/src/content/overwatch-stats.md
+++ b/src/content/overwatch-stats.md
@@ -1,0 +1,12 @@
+A full-stack web application for logging Overwatch competitive matches and analyzing performance over time. A Flask REST API over a SQLAlchemy data model serves a React + TypeScript dashboard where you can search any battle tag to explore win rates per hero, per map, and per role, drill into detailed stat breakdowns, and view trends grouped by day, week, or month.
+
+Match entry enforces real game rules: valid 5v5 and 6v6 team compositions, role-locked hero swaps, and per-team ban limits. An optional scoreboard autofill feature sends an end-of-match screenshot to a Claude vision model along with a labeled grid of hero portraits; the model identifies each player's hero and reads their stat line, filling the form automatically behind a rolling rate limit.
+
+## Features
+
+- Full match logging with enforced 5v5/6v6 team composition, role-locked hero swaps, and per-team ban limits
+- AI scoreboard autofill, where a Claude vision model reads a screenshot and fills every player's hero and stats
+- Player dashboard with overall, per-role, per-hero, and per-map win rates plus drill-down detail views
+- Trend analysis of win rate and match volume grouped by day, week, or month
+- Ranked/unranked and team-size filters that persist across page refreshes
+- Deployed on AWS Lightsail behind Caddy with automatic HTTPS

--- a/src/content/overwatch-stats.md
+++ b/src/content/overwatch-stats.md
@@ -1,12 +1,20 @@
-A full-stack web application for logging Overwatch competitive matches and analyzing performance over time. A Flask REST API over a SQLAlchemy data model serves a React + TypeScript dashboard where you can search any battle tag to explore win rates per hero, per map, and per role, drill into detailed stat breakdowns, and view trends grouped by day, week, or month.
-
-Match entry enforces real game rules: valid 5v5 and 6v6 team compositions, role-locked hero swaps, and per-team ban limits. An optional scoreboard autofill feature sends an end-of-match screenshot to a Claude vision model along with a labeled grid of hero portraits; the model identifies each player's hero and reads their stat line, filling the form automatically behind a rolling rate limit.
+A full-stack web application for logging Overwatch competitive matches and analyzing performance over time. A Flask REST API over a SQLAlchemy data model serves a React + TypeScript dashboard where you can search any battle tag to explore win rates per hero, per map, and per role, drill into detailed stat breakdowns with per-10-minute rates, and view trends grouped by day, week, or month.
 
 ## Features
 
-- Full match logging with enforced 5v5/6v6 team composition, role-locked hero swaps, and per-team ban limits
-- AI scoreboard autofill, where a Claude vision model reads a screenshot and fills every player's hero and stats
-- Player dashboard with overall, per-role, per-hero, and per-map win rates plus drill-down detail views
-- Trend analysis of win rate and match volume grouped by day, week, or month
-- Ranked/unranked and team-size filters that persist across page refreshes
+- Full match logging with enforced 5v5/6v6 team composition, role-locked hero swaps, and a two-ban-per-team cap
+- AI scoreboard autofill: a Claude vision model reads a screenshot against a labeled hero-portrait reference grid and returns all ten players' heroes and stats as schema-validated structured output
+- Player dashboard with overall, per-role, per-hero, and per-map win rates plus per-10-minute stat breakdowns and drill-down detail views
+- Trend analysis of win rate and match volume grouped by day, week, or month, with ranked/unranked and team-size filters that survive a page refresh
+- Labeled evaluation harness that scores hero-identification accuracy on real screenshots and calibrates the portrait crop without spending API calls
 - Deployed on AWS Lightsail behind Caddy with automatic HTTPS
+
+## Implementation details
+
+The schema is built around a `MatchPlayer` row per hero a player used in a match, so hero swaps carry their own stat lines and every aggregate (hero win rates, map preferences, role splits) falls out of the same joins. Match entry enforces real game rules in the form itself: 5v5 requires exactly 1 Tank, 2 Damage, and 2 Supports per team while 6v6 caps Tanks at two, swaps are restricted to heroes of the primary hero's role, and bans are limited to two per team. Players are created automatically the first time a battle tag appears, filters persist across page refreshes via localStorage, and the whole thing runs on a single AWS Lightsail instance behind Caddy with automatic HTTPS.
+
+### AI scoreboard autofill
+
+Rather than typing in ten players' stat lines by hand, you can upload an end-of-match screenshot and have a Claude vision model fill the form. The interesting part is how the request is built: the model receives up to three images: a labeled reference grid of every roster hero's portrait, the screenshot itself, and a 3x-upscaled crop of just the hero-portrait column, extracted with calibrated fractional bounds and gated on the image's aspect ratio matching the match-summary card layout. The reference grid is composed offline by a script that downloads official portraits and prints each hero's exact name beneath its image, turning hero identification into a matching problem against named references instead of recall from training data. The prompt also encodes the scoreboard's structure (role icons mark each row as Tank, Damage, or Support) and forces the model to write down the visual features it actually sees in each portrait before committing to a hero name, with instructions to return an empty string rather than guess.
+
+The response comes back through structured outputs validated against a Pydantic schema, so it is guaranteed parseable, and hero names are checked against the roster again on save. A small eval harness measures per-row hero-identification accuracy against labeled real screenshots, and can dump the portrait crops without any API calls to visually calibrate the crop bounds. Since every parse is a paid API call, the endpoint sits behind an in-memory sliding-window rate limiter — three calls per rolling 24 hours, with a refund when no model call was actually made — plus upload type and size checks.

--- a/src/content/pdf-translator.md
+++ b/src/content/pdf-translator.md
@@ -1,0 +1,10 @@
+An application that translates any PDF into a desired language while keeping the original layout intact. PyMuPDF is used to extract the text and structure of the document and to modify and rebuild the PDF, while OpenAI's GPT-4o performs the translations.
+
+Drop a PDF into the project's pdfs folder, run the main script, and get back a translated document that still looks like the original.
+
+## Features
+
+- Translates PDFs into any target language
+- Preserves the original document formatting
+- PyMuPDF for PDF text extraction and reconstruction
+- OpenAI GPT-4o for the translations

--- a/src/content/pdf-translator.md
+++ b/src/content/pdf-translator.md
@@ -1,10 +1,24 @@
-An application that translates any PDF into a desired language while keeping the original layout intact. PyMuPDF is used to extract the text and structure of the document and to modify and rebuild the PDF, while OpenAI's GPT-4o performs the translations.
-
-Drop a PDF into the project's pdfs folder, run the main script, and get back a translated document that still looks like the original.
+A tool that translates any PDF into a chosen language while keeping the document looking like the original. Instead of dumping the text into a translator and producing a plain-text result, it edits the PDF in place: PyMuPDF extracts every span of text along with its exact position, size, and color, the original text is whited out, and the translation is written back into the same spot on the page.
 
 ## Features
 
-- Translates PDFs into any target language
-- Preserves the original document formatting
-- PyMuPDF for PDF text extraction and reconstruction
-- OpenAI GPT-4o for the translations
+- Translates PDFs into any target language from a simple CLI prompt
+- Preserves the original layout by whiting out and rewriting text in place, span by span
+- Dynamic font sizing fits translations of any length into the original text's bounding box
+- Keeps original text color and leaves images untouched
+- One batched GPT call per page, with a few-shot prompt that keeps fragment positions aligned through JSON
+- Outputs a translated copy alongside the source PDF
+
+## Implementation details
+
+The interesting problem is that a PDF has no idea what a paragraph is. PyMuPDF exposes each page as a tree of blocks, lines, and spans, where a span is just a run of text with one style at one position — so the pipeline works span by span, translating each fragment and fitting the result back into the bounding box the original occupied.
+
+### Preserving the layout
+
+For each page, every non-image block is covered with white rectangles drawn over the span bounding boxes, erasing the source text while leaving images and graphics untouched. Each translated span is then reinserted at its original coordinates in the original color, converted from the span's sRGB value back to PDF color space.
+
+Translated text is rarely the same length as the source, so a fixed font size would overflow or underfill the box. Instead, the insertion routine sizes the text dynamically: starting from a font size of 1, it grows the size until the rendered text would exceed the bounding box's width or height, capped at the original span's font size, then vertically centers the result. The output stays inside the space the original text occupied no matter how the translation's length differs.
+
+### Batching translations through GPT
+
+Rather than one API call per fragment, all spans on a page are numbered and sent to OpenAI's chat completions API (gpt-4o-mini) as a single JSON object mapping position to text. A few-shot system prompt, with the target language substituted in, instructs the model to return the same JSON structure with every value translated and every key and ordering untouched, and includes examples covering markup tags, HTML entities, and numbers that should pass through unchanged. The response is parsed back into a position-to-translation map, so each translated fragment lands exactly on the span it came from.

--- a/src/content/steam-to-spotify.md
+++ b/src/content/steam-to-spotify.md
@@ -1,0 +1,13 @@
+A five-step wizard that turns Steam playtime into a soundtrack playlist. Enter a Steam ID (SteamID64, vanity name, or profile URL) and the app pulls every game played past an adjustable threshold, searches Spotify for each one's official soundtrack, and hands you a shareable playlist or a copyable track list with Spotify links.
+
+Since Spotify has no official-soundtrack flag, a custom scoring heuristic ranks candidate albums, favoring exact-title official releases while disqualifying covers, tributes, and 8-bit/piano rearrangements. An interactive review step lets you pick multiple albums per game (base OST + DLC), exclude games, or search manually when the auto-match isn't confident.
+
+Built to be resilient: one bad match never sinks the batch, Spotify calls are cached in SQLite, and known Spotify development-mode restrictions have explicit fallbacks. Playlist creation works for anonymous users via a bot-account refresh token, with no database and no user login.
+
+## Features
+
+- Imports a Steam library from a SteamID64, vanity name, or profile URL and filters by playtime
+- Heuristic soundtrack matching that scores and ranks Spotify albums, rejecting covers and rearrangements
+- Interactive review step to pick multiple albums per game, exclude games, or manually search Spotify
+- Exports one track, the top 5, or the full album per release as a copyable list or a real public Spotify playlist
+- Per-game error degradation, SQLite-backed caching, and rate limiting for resilience

--- a/src/content/steam-to-spotify.md
+++ b/src/content/steam-to-spotify.md
@@ -1,13 +1,26 @@
-A five-step wizard that turns Steam playtime into a soundtrack playlist. Enter a Steam ID (SteamID64, vanity name, or profile URL) and the app pulls every game played past an adjustable threshold, searches Spotify for each one's official soundtrack, and hands you a shareable playlist or a copyable track list with Spotify links.
-
-Since Spotify has no official-soundtrack flag, a custom scoring heuristic ranks candidate albums, favoring exact-title official releases while disqualifying covers, tributes, and 8-bit/piano rearrangements. An interactive review step lets you pick multiple albums per game (base OST + DLC), exclude games, or search manually when the auto-match isn't confident.
-
-Built to be resilient: one bad match never sinks the batch, Spotify calls are cached in SQLite, and known Spotify development-mode restrictions have explicit fallbacks. Playlist creation works for anonymous users via a bot-account refresh token, with no database and no user login.
+A Next.js web app that turns Steam playtime into a soundtrack playlist. Enter a Steam ID (SteamID64, vanity name, or full profile URL) and a five-step wizard pulls every game played past an adjustable hour threshold, matches each one to its official soundtrack on Spotify, and ends with a copyable track list or a real, shareable public playlist. The whole run lives in client state; each step calls one thin API route that validates input and delegates to a unit-tested `lib/` module.
 
 ## Features
 
-- Imports a Steam library from a SteamID64, vanity name, or profile URL and filters by playtime
-- Heuristic soundtrack matching that scores and ranks Spotify albums, rejecting covers and rearrangements
-- Interactive review step to pick multiple albums per game, exclude games, or manually search Spotify
-- Exports one track, the top 5, or the full album per release as a copyable list or a real public Spotify playlist
-- Per-game error degradation, SQLite-backed caching, and rate limiting for resilience
+- Imports a Steam library from a SteamID64, vanity name, or profile URL and filters by an adjustable playtime threshold
+- Heuristic album scoring that favors exact-title official releases and disqualifies covers, tributes, and 8-bit/piano rearrangements
+- Interactive review step to pick multiple albums per game, exclude games, or search Spotify manually
+- Exports one track, the top 5 by popularity, or the full album per release as a copyable list or a real public Spotify playlist
+- Per-item error degradation, fail-open SQLite caching, and single-retry budgets for expired tokens and rate limits
+- HMAC-signed delete tokens let a playlist's creator remove it later with nothing stored on the server
+
+## Implementation details
+
+The hard part is that Spotify has no "official soundtrack" flag: a search for a game's OST returns the real release mixed in with covers, tributes, and piano rearrangements, so a custom scoring heuristic has to infer which album is the genuine one. The other constraint is that the app runs with no database and no user login, which forces some unusual design: playlists are created on a bot account for anonymous users, and deletion rights are handed out as signed capability tokens instead of server-side records.
+
+### Matching without an OST flag
+
+Each game name is first normalized, with trademark symbols dropped and stacked edition suffixes ("Game of the Year Edition", "Remastered", "Director's Cut") stripped in a loop, then searched twice on Spotify ("*name* original soundtrack" and "*name* soundtrack"). Every candidate album is scored against the game: containing the full game title scores highest, at least 80% token overlap scores a bit less, and anything below that is rejected outright. A strong OST keyword ("original/official soundtrack", including the "sound track" spelling FromSoftware uses) beats a weak one ("OST", "original score"), proper albums edge out singles, and every meaningful title token beyond the game's own name (sequel numbers, "Vol. 5", mod names) costs points, so the exact-title base release ranks first. A disqualifier regex zeroes covers, tributes, karaoke, and piano/lullaby/8-bit rearrangements no matter how well they match.
+
+Candidates under a confidence floor are dropped, and any game whose top match isn't confident is flagged for attention on a review screen, where the user can pick multiple albums per game (base OST plus DLC), exclude games, or run a manual Spotify search. Selected albums then expand into tracks — one per game, the top 5 by Spotify popularity, or the full album — with a fallback to album order when Spotify's development-mode API withholds popularity data.
+
+### Stateless by design
+
+Spotify reads use an app-level client-credentials token, but that grade of token cannot create playlists, so a bot account authorizes the app once, and its OAuth refresh token lets the server publish public playlists on anonymous users' behalf. Since the host's compute instances are ephemeral and there is no database, the creator's right to delete their playlist can't be stored server-side: instead, the creation response includes an HMAC-signed delete token binding the playlist ID, verified later with a timing-safe comparison. The playlist route, being the one privileged write, also gets an Origin-based CSRF check and a per-IP rate limit that the read routes don't need.
+
+Resilience follows the same philosophy throughout: one bad game never sinks a batch (match and track fetches degrade per item), Spotify responses are cached in SQLite with per-kind TTLs (a fail-open cache that turns any storage error into a miss), and expired tokens and 429s each get a single retry that honors Spotify's Retry-After header.

--- a/src/content/tetris.md
+++ b/src/content/tetris.md
@@ -1,11 +1,22 @@
-Adapted from the CMU 15-112 Tetris homework and rebuilt with object-oriented design, then extended with a scoreboard, a next-piece preview, piece holding, and an outline showing where the current piece will drop.
-
-The headline feature is an AI player that simulates every possible move and picks the best one using a heuristic. The heuristic ideas are based on the well-known near-perfect Tetris player, with the weights tuned by a custom genetic algorithm. Scores persist between sessions in an application data folder.
+Adapted from the CMU 15-112 Tetris homework and rebuilt around an object-oriented core (a `Board` class and a `Piece` hierarchy that own their own legality checks, movement, and rendering), then extended well past the assignment: a 7-bag randomizer, next-piece preview, piece holding, a ghost outline showing where the current piece will land, level-based gravity, switchable color themes, a persistent scoreboard, and an AI player that can take over mid-game.
 
 ## Features
 
-- Object-oriented rebuild of the 15-112 Tetris base
-- Scoreboard with scores persisted between sessions
-- Next-piece preview, piece holding, and drop outline
-- AI that simulates all possible moves and picks the best via a heuristic
-- Custom genetic algorithm to tune the AI's heuristic weights
+- Object-oriented rebuild of the 15-112 Tetris base, with 7-bag piece randomization and level-based gravity
+- Next-piece preview, piece holding, and a ghost outline of the drop position
+- AI autopilot that scores all 80 hold/column/rotation placements with a four-factor heuristic
+- Heuristic weights tuned by a custom genetic algorithm with parallel game evaluation, crossover, and mutation
+- High scores persisted between sessions in a per-OS application data folder
+- Remappable controls loaded from a config file, plus two switchable color themes
+
+## Implementation details
+
+Gravity speeds up every five lines, and the scoreboard is written to a per-OS application data folder (APPDATA on Windows, Application Support on macOS). The headline feature is the AI player, toggled mid-game with a single key. Rather than teleporting pieces into place, it plays through the same rules a human does: each timer tick it rotates, shifts one column, or soft-drops the falling piece toward its chosen target, so watching it play looks like a very fast, very decisive human.
+
+### Choosing a move
+
+For every new piece, the AI enumerates the full placement space: hold or don't hold, times every column, times all four rotations, for 80 candidate moves on the 10-wide board. Each candidate is simulated on a deep copy of the board with a hard drop, and the resulting position is scored with a linear heuristic over four board statistics: lines cleared (rewarded), holes — empty cells buried under filled ones (penalized), bumpiness — the summed height difference between adjacent columns (penalized), and aggregate column height (penalized). The move with the best score wins. The four statistics come from the well-known "near-perfect Tetris player" write-up, but the weights do not.
+
+### Tuning the weights with a genetic algorithm
+
+The weights are evolved by a custom genetic algorithm in a separate headless version of the game that shares the real rules (same bag, hold, and scoring). Each generation, a population of weight vectors plays full games in parallel via a multiprocessing pool; the fittest parents survive, single-point crossover swaps one weight between parent pairs, and mutation nudges one random weight by up to half its value. Games also get longer as generations pass: the turn budget grows so surviving agents keep being tested on harder, longer runs. The shipped weights are the output of this process, and they diverge noticeably from the article's published values, most visibly a much heavier penalty on total stack height.

--- a/src/content/tetris.md
+++ b/src/content/tetris.md
@@ -1,0 +1,11 @@
+Adapted from the CMU 15-112 Tetris homework and rebuilt with object-oriented design, then extended with a scoreboard, a next-piece preview, piece holding, and an outline showing where the current piece will drop.
+
+The headline feature is an AI player that simulates every possible move and picks the best one using a heuristic. The heuristic ideas are based on the well-known near-perfect Tetris player, with the weights tuned by a custom genetic algorithm. Scores persist between sessions in an application data folder.
+
+## Features
+
+- Object-oriented rebuild of the 15-112 Tetris base
+- Scoreboard with scores persisted between sessions
+- Next-piece preview, piece holding, and drop outline
+- AI that simulates all possible moves and picks the best via a heuristic
+- Custom genetic algorithm to tune the AI's heuristic weights

--- a/src/content/video-player.md
+++ b/src/content/video-player.md
@@ -1,0 +1,11 @@
+A vanilla-JS, no-build MPEG-DASH video player built on dash.js for experimenting with Adaptive Bitrate (ABR) algorithms. It plays any DASH manifest and lets you swap at runtime between custom ABR rules, including a BBA-0 / throughput hybrid, and dash.js built-ins like BOLA, L2A, and LoLP, rebuilding the player with the selected rule.
+
+Network conditions are emulated for real: a service worker meters media-segment download bytes to a capped rate, so dash.js's throughput estimate genuinely reflects the cap and the ABR rules react to it. A variable-bandwidth mode drives the cap with a random walk to mimic real network congestion, and a live canvas strip chart plots throughput, the emulated cap, the playing bitrate, and buffer level over a rolling 60-second window with quality-switch markers and a hover crosshair.
+
+## Features
+
+- Plays any DASH manifest URL with the Sintel test stream as a default
+- Switchable ABR rules at runtime: custom rules (BBA-0/throughput hybrid, lowest, highest) and dash.js built-ins (Throughput, BOLA, L2A, LoLP, and more)
+- Real network emulation via a service worker that throttles segment downloads to preset caps from 300 kbps to 5 Mbps
+- Variable-bandwidth mode that drifts the cap with a configurable random walk to simulate network congestion
+- Live metrics chart sampling throughput, cap, playing bitrate, and buffer level every 500 ms with quality-switch markers and a hover crosshair

--- a/src/content/video-player.md
+++ b/src/content/video-player.md
@@ -1,11 +1,24 @@
-A vanilla-JS, no-build MPEG-DASH video player built on dash.js for experimenting with Adaptive Bitrate (ABR) algorithms. It plays any DASH manifest and lets you swap at runtime between custom ABR rules, including a BBA-0 / throughput hybrid, and dash.js built-ins like BOLA, L2A, and LoLP, rebuilding the player with the selected rule.
-
-Network conditions are emulated for real: a service worker meters media-segment download bytes to a capped rate, so dash.js's throughput estimate genuinely reflects the cap and the ABR rules react to it. A variable-bandwidth mode drives the cap with a random walk to mimic real network congestion, and a live canvas strip chart plots throughput, the emulated cap, the playing bitrate, and buffer level over a rolling 60-second window with quality-switch markers and a hover crosshair.
+A vanilla-JS, no-build MPEG-DASH video player built on dash.js for experimenting with Adaptive Bitrate (ABR) algorithms. It plays any DASH manifest (with the Sintel test stream as a default) and lets you swap ABR rules at runtime (a custom BBA-0/throughput hybrid, pinned lowest/highest rules, or dash.js built-ins like BOLA, L2A, and LoLP), with each switch tearing down and rebuilding the player under the selected rule.
 
 ## Features
 
-- Plays any DASH manifest URL with the Sintel test stream as a default
-- Switchable ABR rules at runtime: custom rules (BBA-0/throughput hybrid, lowest, highest) and dash.js built-ins (Throughput, BOLA, L2A, LoLP, and more)
-- Real network emulation via a service worker that throttles segment downloads to preset caps from 300 kbps to 5 Mbps
-- Variable-bandwidth mode that drifts the cap with a configurable random walk to simulate network congestion
-- Live metrics chart sampling throughput, cap, playing bitrate, and buffer level every 500 ms with quality-switch markers and a hover crosshair
+- Plays any DASH manifest URL, with the Sintel test stream as a default
+- Runtime-switchable ABR rules: a custom BBA-0/throughput hybrid, pinned lowest/highest, and dash.js built-ins (Throughput, BOLA, L2A, LoLP, and more)
+- Real network emulation via a service worker that meters segment downloads with a token-bucket limiter, so dash.js's throughput estimate reflects the cap
+- Variable-bandwidth mode that drifts the cap with a bounded random walk at three volatility levels
+- Live dual-axis metrics chart sampling throughput, cap, playing bitrate, and buffer level every 500 ms, with quality-switch markers and a hover crosshair
+- Timeline stays continuous across rule switches, even though each switch rebuilds the player from scratch
+
+## Implementation details
+
+When a custom rule is active, every built-in rule is disabled, so the decisions on screen come from exactly one algorithm. What makes the testbed honest is that nothing is faked: segments genuinely download slowly through an emulated network cap, dash.js's own throughput estimator measures that constrained bandwidth, and the ABR rules react to it exactly as they would on a real bad connection. A live canvas strip chart plots measured throughput, the emulated cap, the playing bitrate, and buffer level over a rolling 60-second window, so you can watch a rule ride out a bandwidth drop — or fail to.
+
+### The custom ABR rule
+
+The custom rule is a hybrid of buffer-based BBA-0 and throughput-based selection, keyed off the current buffer level. Below a 2-second critical reservoir it drops straight to the lowest rendition to avoid a stall. Between 2 and 5 seconds it plays it safe with throughput: it picks the highest rendition whose bitrate fits under 90% of dash.js's safe average throughput estimate. Once the buffer clears the reservoir, BBA-0 takes over: the buffer's position inside a 10-second cushion is mapped linearly onto the manifest's bitrate range, so quality climbs smoothly as the buffer fills, and past 15 seconds the rule commits to the highest rendition. Playback always starts at the lowest quality, and a switch request is only issued when the target rendition actually changes, which keeps the rule from thrashing.
+
+### Throttling below the network stack
+
+Browser dev-tools throttling doesn't help here, and dash.js v5 fetches segments over XHR rather than `fetch`, so the emulation lives in a service worker — the one place that sits below both. The worker intercepts only media-segment requests (manifests and app assets pass through untouched) and re-streams each response body through a token-bucket rate limiter that releases bytes at the capped rate, with bursts limited to about one second's allowance. The cap is re-read on every chunk, so changing the preset mid-download takes effect immediately.
+
+On top of the fixed presets (300 kbps up to 5 Mbps), a variable-bandwidth mode drives the cap with a random walk: every 500 ms it nudges the cap by a step drawn from the sum of two uniform randoms (biasing toward small moves), scaled by a configurable volatility and clamped to user-set bounds. The result is a plausibly jittery connection for stress-testing how each ABR rule handles congestion rather than a clean step function.

--- a/src/data/projects.json
+++ b/src/data/projects.json
@@ -5,19 +5,6 @@
     "date": "Jul 2026",
     "imageSrc": "projects/hollow-knight-bot.png",
     "description": "Reinforcement-learning agent that learns to fight Hornet in the real Hollow Knight game, trained with PPO through a custom C# mod that runs the game in lockstep with the trainer.",
-    "longDescription": [
-      "A PPO agent that fights Hornet (Hall of Gods, Attuned) inside the actual game, with no emulator or pixel input. A custom C# mod runs inside Hollow Knight and exposes a TCP bridge: the trainer sends button presses, the mod holds them for one 67 ms tick, samples the game state (positions, velocities, HP, SOUL, Hornet's FSM state), and replies. The agent decides at 15 Hz among 21 discrete moves, and because buttons stay held across repeated steps, jump height, healing, and nail-art charging are all emergent behaviors.",
-      "The mod drives every episode reset itself: from a fresh boot it navigates the title menu, stands up from the Hall of Gods bench, runs to the statue, and starts the fight with no human input. On the Python side, a Gymnasium environment wraps the bridge, and a supervisor layer makes training fault-tolerant end to end. It launches and owns the game process, reconnects through resets, and relaunches the game if it wedges or crashes, so an overnight run survives anything short of a power cut.",
-      "Training scales to multiple game instances in parallel, each a slot of the same vectorized PPO with its own copy-on-write app clone for save isolation and a keepalive pinger to hold connections through lockstep gaps. A web dashboard tracks every run (learning curves, win rate, steps/hour, ETA) and can start, resume, and stop training itself. Checkpoints every 15k steps mean a crash never loses more than about 17 minutes of progress."
-    ],
-    "features": [
-      "C# game mod with a TCP bridge that runs the real game in 67 ms lockstep with the trainer",
-      "Fully automated episode resets: the mod boots the game from title screen to boss fight with no human input",
-      "Fault-tolerant training supervisor that relaunches crashed or wedged game processes and resumes mid-run",
-      "Multi-instance training with per-instance save sandboxes (APFS copy-on-write app clones) for roughly N-times sample throughput",
-      "Web dashboard that launches, monitors, and stops runs, with per-generation learning curves and live episode rewards",
-      "Checkpointed \"generations\" with full resume (weights plus observation-normalization stats) and replay of any checkpoint"
-    ],
     "skills": [
       "Python",
       "C#",
@@ -34,18 +21,6 @@
     "date": "Jul 2026",
     "imageSrc": "projects/steam-to-spotify.png",
     "description": "Web app that turns a Steam library into a Spotify playlist by matching every game you've played to its official soundtrack.",
-    "longDescription": [
-      "A five-step wizard that turns Steam playtime into a soundtrack playlist. Enter a Steam ID (SteamID64, vanity name, or profile URL) and the app pulls every game played past an adjustable threshold, searches Spotify for each one's official soundtrack, and hands you a shareable playlist or a copyable track list with Spotify links.",
-      "Since Spotify has no official-soundtrack flag, a custom scoring heuristic ranks candidate albums, favoring exact-title official releases while disqualifying covers, tributes, and 8-bit/piano rearrangements. An interactive review step lets you pick multiple albums per game (base OST + DLC), exclude games, or search manually when the auto-match isn't confident.",
-      "Built to be resilient: one bad match never sinks the batch, Spotify calls are cached in SQLite, and known Spotify development-mode restrictions have explicit fallbacks. Playlist creation works for anonymous users via a bot-account refresh token, with no database and no user login."
-    ],
-    "features": [
-      "Imports a Steam library from a SteamID64, vanity name, or profile URL and filters by playtime",
-      "Heuristic soundtrack matching that scores and ranks Spotify albums, rejecting covers and rearrangements",
-      "Interactive review step to pick multiple albums per game, exclude games, or manually search Spotify",
-      "Exports one track, the top 5, or the full album per release as a copyable list or a real public Spotify playlist",
-      "Per-game error degradation, SQLite-backed caching, and rate limiting for resilience"
-    ],
     "skills": [
       "TypeScript",
       "Next.js",
@@ -65,18 +40,6 @@
     "date": "Jun - Jul 2026",
     "imageSrc": "projects/overwatch-stats.png",
     "description": "Web app for logging Overwatch competitive matches and analyzing hero, map, and trend performance, with AI-powered scoreboard autofill.",
-    "longDescription": [
-      "A full-stack web application for logging Overwatch competitive matches and analyzing performance over time. A Flask REST API over a SQLAlchemy data model serves a React + TypeScript dashboard where you can search any battle tag to explore win rates per hero, per map, and per role, drill into detailed stat breakdowns, and view trends grouped by day, week, or month.",
-      "Match entry enforces real game rules: valid 5v5 and 6v6 team compositions, role-locked hero swaps, and per-team ban limits. An optional scoreboard autofill feature sends an end-of-match screenshot to a Claude vision model along with a labeled grid of hero portraits; the model identifies each player's hero and reads their stat line, filling the form automatically behind a rolling rate limit."
-    ],
-    "features": [
-      "Full match logging with enforced 5v5/6v6 team composition, role-locked hero swaps, and per-team ban limits",
-      "AI scoreboard autofill, where a Claude vision model reads a screenshot and fills every player's hero and stats",
-      "Player dashboard with overall, per-role, per-hero, and per-map win rates plus drill-down detail views",
-      "Trend analysis of win rate and match volume grouped by day, week, or month",
-      "Ranked/unranked and team-size filters that persist across page refreshes",
-      "Deployed on AWS Lightsail behind Caddy with automatic HTTPS"
-    ],
     "skills": [
       "Python",
       "Claude API",
@@ -95,17 +58,6 @@
     "date": "Jan 2026",
     "imageSrc": "projects/video-player.png",
     "description": "Browser-based MPEG-DASH video player for experimenting with adaptive bitrate algorithms under emulated network conditions.",
-    "longDescription": [
-      "A vanilla-JS, no-build MPEG-DASH video player built on dash.js for experimenting with Adaptive Bitrate (ABR) algorithms. It plays any DASH manifest and lets you swap at runtime between custom ABR rules, including a BBA-0 / throughput hybrid, and dash.js built-ins like BOLA, L2A, and LoLP, rebuilding the player with the selected rule.",
-      "Network conditions are emulated for real: a service worker meters media-segment download bytes to a capped rate, so dash.js's throughput estimate genuinely reflects the cap and the ABR rules react to it. A variable-bandwidth mode drives the cap with a random walk to mimic real network congestion, and a live canvas strip chart plots throughput, the emulated cap, the playing bitrate, and buffer level over a rolling 60-second window with quality-switch markers and a hover crosshair."
-    ],
-    "features": [
-      "Plays any DASH manifest URL with the Sintel test stream as a default",
-      "Switchable ABR rules at runtime: custom rules (BBA-0/throughput hybrid, lowest, highest) and dash.js built-ins (Throughput, BOLA, L2A, LoLP, and more)",
-      "Real network emulation via a service worker that throttles segment downloads to preset caps from 300 kbps to 5 Mbps",
-      "Variable-bandwidth mode that drifts the cap with a configurable random walk to simulate network congestion",
-      "Live metrics chart sampling throughput, cap, playing bitrate, and buffer level every 500 ms with quality-switch markers and a hover crosshair"
-    ],
     "skills": [
       "JavaScript",
       "dash.js"
@@ -120,16 +72,6 @@
     "date": "Jan 2026",
     "imageSrc": "projects/integrity-check.png",
     "description": "Command line tool to verify file integrity by using cryptographic hashing algorithms to detect changes.",
-    "longDescription": [
-      "A command line tool that verifies the integrity of files by computing cryptographic hashes with SHA-256 and comparing them against a stored baseline. It accepts either a single log file or an entire directory, and clearly reports any discrepancies that indicate possible file tampering.",
-      "The tool works in three modes: init computes and securely stores the hashes of the given file or directory, check re-computes them and compares against the stored baseline, and update re-initializes the baseline after intentional changes."
-    ],
-    "features": [
-      "Accepts a single file or an entire directory as input",
-      "Computes SHA-256 hashes and stores them securely on first use",
-      "Reports discrepancies that indicate possible file tampering",
-      "init / check / update commands for initializing, verifying, and re-baselining hashes"
-    ],
     "skills": [
       "Rust",
       "SQL"
@@ -143,16 +85,6 @@
     "date": "Jul 2024",
     "imageSrc": "projects/pdf-translate.png",
     "description": "Application to translate PDFs to any language while keeping the original format using GPT models for translations.",
-    "longDescription": [
-      "An application that translates any PDF into a desired language while keeping the original layout intact. PyMuPDF is used to extract the text and structure of the document and to modify and rebuild the PDF, while OpenAI's GPT-4o performs the translations.",
-      "Drop a PDF into the project's pdfs folder, run the main script, and get back a translated document that still looks like the original."
-    ],
-    "features": [
-      "Translates PDFs into any target language",
-      "Preserves the original document formatting",
-      "PyMuPDF for PDF text extraction and reconstruction",
-      "OpenAI GPT-4o for the translations"
-    ],
     "skills": [
       "Python",
       "OpenAI"
@@ -166,16 +98,6 @@
     "date": "Jun - Jul 2024",
     "imageSrc": "projects/game-embedding.png",
     "description": "Visualizations of steam game descriptions using SBERT alongside dimension reduction and query generation for search.",
-    "longDescription": [
-      "Steam game descriptions are embedded with a Sentence Transformer and visualized using multiple dimension reduction techniques, including PCA, t-SNE, and PaCMAP, to explore how games cluster by their content.",
-      "The model is also fine-tuned on a variety of generated queries so that games can be searched by genre, and LIME is used to explain which parts of a query and description led to a game being matched. The data comes from the Steam Games Dataset on Kaggle."
-    ],
-    "features": [
-      "Sentence Transformer (SBERT) embeddings of game descriptions",
-      "Visualizations with PCA, t-SNE, and PaCMAP dimension reduction",
-      "Fine-tuned on generated queries to support genre-based game search",
-      "LIME explanations for why a game matches a search query"
-    ],
     "skills": [
       "Jupyter",
       "ML"
@@ -189,16 +111,6 @@
     "date": "Jan 2024",
     "imageSrc": "projects/dec-tree.png",
     "description": "This is a project made to learn the data analysis and machine learning models to detect transaction frauds.",
-    "longDescription": [
-      "A machine learning project exploring different models and proper handling of heavily imbalanced data to detect fraudulent credit card transactions, built on a public fraud-detection dataset from Kaggle.",
-      "After exploratory data analysis to identify patterns between features, the class imbalance was addressed with SMOTE oversampling and Tomek Links undersampling. Random Forest, AdaBoost, and XGBoost models were trained and compared, and the results were analyzed with SHAP values to understand feature importance and relationships."
-    ],
-    "features": [
-      "Exploratory data analysis of transaction patterns",
-      "SMOTE and Tomek Links to handle imbalanced classes",
-      "Random Forest, AdaBoost, and XGBoost model comparison",
-      "SHAP value analysis of feature importance"
-    ],
     "skills": [
       "Jupyter",
       "ML"
@@ -212,17 +124,6 @@
     "date": "Oct 2021 - Feb 2022",
     "imageSrc": "projects/tetris.png",
     "description": "This is a project adapted from a homework from 15-112 at CMU with multiple additional features including an AI.",
-    "longDescription": [
-      "Adapted from the CMU 15-112 Tetris homework and rebuilt with object-oriented design, then extended with a scoreboard, a next-piece preview, piece holding, and an outline showing where the current piece will drop.",
-      "The headline feature is an AI player that simulates every possible move and picks the best one using a heuristic. The heuristic ideas are based on the well-known near-perfect Tetris player, with the weights tuned by a custom genetic algorithm. Scores persist between sessions in an application data folder."
-    ],
-    "features": [
-      "Object-oriented rebuild of the 15-112 Tetris base",
-      "Scoreboard with scores persisted between sessions",
-      "Next-piece preview, piece holding, and drop outline",
-      "AI that simulates all possible moves and picks the best via a heuristic",
-      "Custom genetic algorithm to tune the AI's heuristic weights"
-    ],
     "skills": [
       "Python",
       "AI",
@@ -238,17 +139,6 @@
     "date": "Nov - Dec 2021",
     "imageSrc": "projects/maze.png",
     "description": "A 15-112 term project with the focus on implementing maze-generation, pathfinding and raycasting.",
-    "longDescription": [
-      "A 15-112 term project: a maze game that uses raycasting to render 3D visuals. The objective is to collect a key and reach the end of the maze, with key and enemy placements randomized on every run.",
-      "Difficulty increases as you progress, with longer mazes built with different maze-generation algorithms and enemies driven by different pathfinding algorithms. A toggleable minimap, a path-hint that reveals the way to the next objective, and full camera controls round out the game."
-    ],
-    "features": [
-      "3D visuals rendered with raycasting",
-      "Multiple maze-generation algorithms as levels progress",
-      "Enemies driven by different pathfinding algorithms",
-      "Path hints to the next objective and a toggleable minimap",
-      "Randomized key and enemy placement every run"
-    ],
     "skills": [
       "Python",
       "tkinter"

--- a/src/pages/ProjectContent.jsx
+++ b/src/pages/ProjectContent.jsx
@@ -4,6 +4,12 @@ import rehypeRaw from "rehype-raw";
 import { getImageUrl } from "../utils";
 import styles from "./ProjectPage.module.css";
 
+// Content files live at src/content/<slug>.md (slug = "slug" field in projects.json).
+// Conventions: headings start at ##; image/video paths are relative to the top-level
+// assets/ dir (e.g. "projects/foo.png") and resolved via getImageUrl; ![](clip.mp4)
+// or ![](clip.webm) renders a <video>; paste YouTube's <iframe> embed snippet for
+// YouTube videos; absolute http(s) URLs pass through untouched.
+
 const contentFiles = import.meta.glob("../content/*.md", {
   query: "?raw",
   import: "default",
@@ -28,6 +34,7 @@ const Media = ({ src = "", alt = "" }) => {
   return <img className={styles.media} src={url} alt={alt} />;
 };
 
+// eslint-disable-next-line no-unused-vars
 const Embed = ({ node: _node, ...props }) => (
   <div className={styles.embed}>
     <iframe {...props} />

--- a/src/pages/ProjectContent.jsx
+++ b/src/pages/ProjectContent.jsx
@@ -1,0 +1,54 @@
+import Markdown from "react-markdown";
+import rehypeRaw from "rehype-raw";
+
+import { getImageUrl } from "../utils";
+import styles from "./ProjectPage.module.css";
+
+const contentFiles = import.meta.glob("../content/*.md", {
+  query: "?raw",
+  import: "default",
+  eager: true,
+});
+
+const contentBySlug = Object.fromEntries(
+  Object.entries(contentFiles).map(([path, content]) => [
+    path.slice("../content/".length, -".md".length),
+    content,
+  ])
+);
+
+const resolveSrc = (src = "") =>
+  /^https?:\/\//.test(src) ? src : getImageUrl(src);
+
+const Media = ({ src = "", alt = "" }) => {
+  const url = resolveSrc(src);
+  if (/\.(mp4|webm)$/i.test(src)) {
+    return <video className={styles.media} src={url} controls playsInline />;
+  }
+  return <img className={styles.media} src={url} alt={alt} />;
+};
+
+const Embed = ({ node: _node, ...props }) => (
+  <div className={styles.embed}>
+    <iframe {...props} />
+  </div>
+);
+
+export const ProjectContent = ({ slug, fallback }) => {
+  const content = contentBySlug[slug];
+
+  if (!content) {
+    return <p className={styles.paragraph}>{fallback}</p>;
+  }
+
+  return (
+    <div className={styles.markdown}>
+      <Markdown
+        rehypePlugins={[rehypeRaw]}
+        components={{ img: Media, iframe: Embed }}
+      >
+        {content}
+      </Markdown>
+    </div>
+  );
+};

--- a/src/pages/ProjectPage.jsx
+++ b/src/pages/ProjectPage.jsx
@@ -4,6 +4,7 @@ import { Link, Navigate, useParams } from "react-router-dom";
 import { NavBar } from "../components/NavBar/NavBar";
 import projects from "../data/projects.json";
 import { getImageUrl } from "../utils";
+import { ProjectContent } from "./ProjectContent";
 import styles from "./ProjectPage.module.css";
 
 export const ProjectPage = () => {
@@ -18,23 +19,7 @@ export const ProjectPage = () => {
     return <Navigate to="/projects" replace />;
   }
 
-  const {
-    title,
-    date,
-    imageSrc,
-    description,
-    skills,
-    demo,
-    source,
-    longDescription,
-    features,
-    gallery,
-  } = project;
-
-  const paragraphs =
-    Array.isArray(longDescription) && longDescription.length
-      ? longDescription
-      : [description];
+  const { title, date, imageSrc, description, skills, demo, source } = project;
 
   return (
     <>
@@ -56,44 +41,7 @@ export const ProjectPage = () => {
           alt={`Image of ${title}`}
           className={styles.heroImage}
         />
-        {paragraphs.map((paragraph, id) => {
-          return (
-            <p key={id} className={styles.paragraph}>
-              {paragraph}
-            </p>
-          );
-        })}
-        {features?.length > 0 && (
-          <>
-            <h3 className={styles.sectionTitle}>Features</h3>
-            <ul className={styles.features}>
-              {features.map((feature, id) => {
-                return (
-                  <li key={id} className={styles.feature}>
-                    {feature}
-                  </li>
-                );
-              })}
-            </ul>
-          </>
-        )}
-        {gallery?.length > 0 && (
-          <>
-            <h3 className={styles.sectionTitle}>Gallery</h3>
-            <div className={styles.gallery}>
-              {gallery.map((image, id) => {
-                return (
-                  <img
-                    key={id}
-                    src={getImageUrl(image)}
-                    alt={`Screenshot ${id + 1} of ${title}`}
-                    className={styles.galleryImage}
-                  />
-                );
-              })}
-            </div>
-          </>
-        )}
+        <ProjectContent slug={slug} fallback={description} />
         <div className={styles.links}>
           {source && (
             <a

--- a/src/pages/ProjectPage.module.css
+++ b/src/pages/ProjectPage.module.css
@@ -60,39 +60,6 @@
     line-height: 1.6;
 }
 
-.sectionTitle {
-    margin-top: 40px;
-    font-size: 26px;
-    font-weight: 700;
-    letter-spacing: 1.3px;
-    text-transform: uppercase;
-}
-
-.features {
-    margin-top: 16px;
-    padding-left: 24px;
-}
-
-.feature {
-    font-size: 20px;
-    font-weight: 400;
-    color: var(--color-text);
-    line-height: 1.6;
-    margin-top: 8px;
-}
-
-.gallery {
-    margin-top: 16px;
-    display: grid;
-    grid-template-columns: repeat(auto-fill, minmax(260px, 1fr));
-    gap: 16px;
-}
-
-.galleryImage {
-    width: 100%;
-    border-radius: 10px;
-}
-
 .links {
     margin-top: 40px;
     display: flex;

--- a/src/pages/ProjectPage.module.css
+++ b/src/pages/ProjectPage.module.css
@@ -161,3 +161,63 @@
     transform: translateY(-2px);
     box-shadow: 0 6px 20px var(--color-glow);
 }
+
+.markdown p {
+    margin-top: 24px;
+    font-size: 20px;
+    font-weight: 400;
+    color: var(--color-text);
+    line-height: 1.6;
+}
+
+.markdown h2 {
+    margin-top: 40px;
+    font-size: 26px;
+    font-weight: 700;
+    letter-spacing: 1.3px;
+    text-transform: uppercase;
+}
+
+.markdown h3 {
+    margin-top: 32px;
+    font-size: 22px;
+    font-weight: 600;
+    letter-spacing: 1.1px;
+}
+
+.markdown ul,
+.markdown ol {
+    margin-top: 16px;
+    padding-left: 24px;
+}
+
+.markdown li {
+    font-size: 20px;
+    font-weight: 400;
+    color: var(--color-text);
+    line-height: 1.6;
+    margin-top: 8px;
+}
+
+.markdown a {
+    color: var(--color-text-bold);
+}
+
+.media {
+    display: block;
+    margin: 26px auto 0;
+    max-width: 100%;
+    border-radius: 10px;
+}
+
+.embed {
+    margin-top: 26px;
+    aspect-ratio: 16 / 9;
+}
+
+.embed iframe {
+    width: 100%;
+    height: 100%;
+    border: 0;
+    border-radius: 10px;
+}


### PR DESCRIPTION
## Summary
- Project page bodies now render from per-project Markdown files in `src/content/` (via react-markdown), replacing the `longDescription`/`features` fields in `projects.json`; images, local video, and iframe embeds are supported in content files
- All ten project writeups were expanded with implementation detail sourced from each project's actual repository, then standardized to a shared structure: summary, Features list, and an Implementation details section with technical subsections